### PR TITLE
Add target for asm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
-.PHONY: clean lint
+.PHONY: clean lint compile-programs-asm compile-programs-yul
 
 ARTIFACTS_DIR=./program_artifacts
 PROGRAMS_DIR=./programs
-ZKSOLC_FLAGS=--asm --bin --yul --overwrite
+ZKSOLC_YUL_FLAGS=--asm --bin --yul --overwrite
 
-PROGRAMS = $(wildcard $(PROGRAMS_DIR)/*.yul)
-ARTIFACTS = $(patsubst $(PROGRAMS_DIR)/%.yul, $(ARTIFACTS_DIR)/%.artifacts, $(PROGRAMS))
+YUL_PROGRAMS = $(wildcard $(PROGRAMS_DIR)/*.yul)
+ASM_PROGRAMS = $(wildcard $(PROGRAMS_DIR)/*.zasm)
+ARTIFACTS_YUL = $(patsubst $(PROGRAMS_DIR)/%.yul, $(ARTIFACTS_DIR)/%.artifacts.yul, $(YUL_PROGRAMS))
+ARTIFACTS_ASM = $(patsubst $(PROGRAMS_DIR)/%.zasm, $(ARTIFACTS_DIR)/%.artifacts.zasm, $(ASM_PROGRAMS))
 
-compile-programs: $(ARTIFACTS)
+compile-programs-asm: $(ARTIFACTS_ASM)
+compile-programs-yul: $(ARTIFACTS_YUL)
 
-$(ARTIFACTS_DIR)/%.artifacts: $(PROGRAMS_DIR)/%.yul
-	zksolc $(ZKSOLC_FLAGS) $< -o $@ --debug-output-dir $@
+compile-programs: clean compile-programs-asm compile-programs-yul
+
+$(ARTIFACTS_DIR)/%.artifacts.yul: $(PROGRAMS_DIR)/%.yul
+	zksolc $(ZKSOLC_YUL_FLAGS) $< -o $@ --debug-output-dir $@
+
+$(ARTIFACTS_DIR)/%.artifacts.zasm: $(PROGRAMS_DIR)/%.zasm
+	zksolc --zkasm  $< -o $@ --debug-output-dir $@
 
 clean:
 	-rm -rf $(ARTIFACTS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 ARTIFACTS_DIR=./program_artifacts
 PROGRAMS_DIR=./programs
 ZKSOLC_YUL_FLAGS=--asm --bin --yul --overwrite
+ZKSOLC_ASM_FLAGS=--zkasm --bin --overwrite
 
 YUL_PROGRAMS = $(wildcard $(PROGRAMS_DIR)/*.yul)
 ASM_PROGRAMS = $(wildcard $(PROGRAMS_DIR)/*.zasm)
@@ -18,7 +19,7 @@ $(ARTIFACTS_DIR)/%.artifacts.yul: $(PROGRAMS_DIR)/%.yul
 	zksolc $(ZKSOLC_YUL_FLAGS) $< -o $@ --debug-output-dir $@
 
 $(ARTIFACTS_DIR)/%.artifacts.zasm: $(PROGRAMS_DIR)/%.zasm
-	zksolc --zkasm  $< -o $@ --debug-output-dir $@
+	zksolc $(ZKSOLC_ASM_FLAGS)  $< -o $@ --debug-output-dir $@
 
 clean:
 	-rm -rf $(ARTIFACTS_DIR)

--- a/move_artifacts.sh
+++ b/move_artifacts.sh
@@ -13,6 +13,5 @@ set -e
 
 for dir in ./program_artifacts/*/
 do
-    echo ${dir}
     mv ${dir}/programs/* ${dir}/
 done

--- a/move_artifacts.sh
+++ b/move_artifacts.sh
@@ -13,5 +13,6 @@ set -e
 
 for dir in ./program_artifacts/*/
 do
+    echo ${dir}
     mv ${dir}/programs/* ${dir}/
 done

--- a/programs/add.zasm
+++ b/programs/add.zasm
@@ -1,0 +1,13 @@
+	.text
+	.file	"add.yul"
+	.globl	__entry
+__entry:
+.func_begin0:
+	add	3, r0, r1
+	sstore	r0, r1
+	add	r0, r0, r1
+	ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/programs/sub.zasm
+++ b/programs/sub.zasm
@@ -1,0 +1,11 @@
+	.text
+	.file	"add.yul"
+	.globl	__entry
+__entry:
+.func_begin0:
+	sub	3, r0, r1
+	ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,11 +5,17 @@ use u256::U256;
 const ARTIFACTS_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/program_artifacts");
 
 fn make_bin_path_yul(file_name: &str) -> String {
-    format!("{}/{}.artifacts.yul/{}.yul.zbin", ARTIFACTS_PATH, file_name, file_name)
+    format!(
+        "{}/{}.artifacts.yul/{}.yul.zbin",
+        ARTIFACTS_PATH, file_name, file_name
+    )
 }
 
 fn make_bin_path_asm(file_name: &str) -> String {
-    format!("{}/{}.artifacts.zasm/{}.zasm.zbin", ARTIFACTS_PATH, file_name, file_name)
+    format!(
+        "{}/{}.artifacts.zasm/{}.zasm.zbin",
+        ARTIFACTS_PATH, file_name, file_name
+    )
 }
 
 #[test]
@@ -21,7 +27,7 @@ fn test_add_yul() {
 }
 
 #[test]
-fn test_add_asm(){
+fn test_add_asm() {
     let bin_path = make_bin_path_asm("add");
     let result = run_program(&bin_path);
     assert_eq!(result, U256::from_dec_str("3").unwrap());
@@ -29,7 +35,7 @@ fn test_add_asm(){
 
 #[test]
 #[should_panic]
-fn test_sub_asm(){
+fn test_sub_asm() {
     let bin_path = make_bin_path_asm("sub");
     let result = run_program(&bin_path);
     assert_eq!(result, U256::from_dec_str("3").unwrap());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,9 +1,36 @@
+use std::path::PathBuf;
+
 use era_vm::run_program;
 use u256::U256;
+const ARTIFACTS_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/program_artifacts");
+
+fn make_bin_path_yul(file_name: &str) -> String {
+    format!("{}/{}.artifacts.yul/{}.yul.zbin", ARTIFACTS_PATH, file_name, file_name)
+}
+
+fn make_bin_path_asm(file_name: &str) -> String {
+    format!("{}/{}.artifacts.zasm/{}.zasm.zbin", ARTIFACTS_PATH, file_name, file_name)
+}
 
 #[test]
-fn test_add() {
-    let bin_path = "./program_artifacts/add.artifacts/add.yul.zbin";
-    let result = run_program(bin_path);
+fn test_add_yul() {
+    let bin_path = make_bin_path_yul("add");
+    dbg!(&bin_path);
+    let result = run_program(&bin_path);
+    assert_eq!(result, U256::from_dec_str("3").unwrap());
+}
+
+#[test]
+fn test_add_asm(){
+    let bin_path = make_bin_path_asm("add");
+    let result = run_program(&bin_path);
+    assert_eq!(result, U256::from_dec_str("3").unwrap());
+}
+
+#[test]
+#[should_panic]
+fn test_sub_asm(){
+    let bin_path = make_bin_path_asm("sub");
+    let result = run_program(&bin_path);
     assert_eq!(result, U256::from_dec_str("3").unwrap());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use era_vm::run_program;
 use u256::U256;
 const ARTIFACTS_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/program_artifacts");


### PR DESCRIPTION
## Changes:
- Add make target to also compile .zasm files.
- Add add a 'sub' and 'add' example programs.