### PR TITLE
Fix readme example path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cargo run -- <path_to_bin>
 As an example, if you are running the `add.yul` program mentioned above, you need to run
 
 ```
-cargo run -- program_artifacts/add.artifacts.yul/programs/add.yul.zbin
+cargo run -- program_artifacts/add.artifacts.yul/add.yul.zbin
 ```
 
 ## Documentation


### PR DESCRIPTION
## Problem Description

While running the following command to execute an example:
```sh
MacBook-Pro-2:era_vm jordi$ cargo run -- program_artifacts/add.artifacts.yul/programs/add.yul.zbin
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/main program_artifacts/add.artifacts.yul/programs/add.yul.zbin`
thread 'main' panicked at src/lib.rs:30:43:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
An error occurred because the specified file was not found. This was due to an incorrect file path provided.

## Solution

To fix this issue, use the correct file path. The correct command is:

```sh
MacBook-Pro-2:era_vm jordi$ cargo run -- program_artifacts/add.artifacts.yul/add.yul.zbin
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/main program_artifacts/add.artifacts.yul/add.yul.zbin`
RESULT: (3, VMState { registers: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], flag_lt_of: false, flag_gt: false, flag_eq: false, current_frame: CallFrame { stack: Stack { stack: [] }, heap: [], code_page: [80985152650915275487740123996942503699944213237826591620499058525229, 107839793410209822991270731559218208947103400392988870264627740540928, 72737211418442222195964830482031894321077592643636372547175210224823858070711], pc: 3, storage: {0: 3} }, gas_left: 60013 })
```