### PR TITLE
Implementing `Shift` instructions

### DIFF
--- a/programs/rol.zasm
+++ b/programs/rol.zasm
@@ -1,0 +1,13 @@
+	.text
+	.file	"rol.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    add	1, r0, r1
+    add 4, r0, r2
+    rol r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+    .note.GNU-stack
+    .rodata

--- a/programs/rol_conditional_eq.zasm
+++ b/programs/rol_conditional_eq.zasm
@@ -1,0 +1,13 @@
+	.text
+	.file	"rol_conditional_eq.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    add	1, r0, r1
+    add 4, r0, r2
+    rol.eq r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+    .note.GNU-stack
+    .rodata

--- a/programs/rol_greater_than_256.zasm
+++ b/programs/rol_greater_than_256.zasm
@@ -1,0 +1,12 @@
+	.text
+	.file	"rol_greater_than_256.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    ; test sets r1 = 1, r2 = 258
+    rol r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+    .note.GNU-stack
+    .rodata

--- a/programs/rol_sets_eq_flag.zasm
+++ b/programs/rol_sets_eq_flag.zasm
@@ -4,10 +4,10 @@
 __entry:
 
 .func_begin0:
-    ; EQ is set if the result is zero
+	; EQ is set if the result is zero
 	add	0, r0, r1
 	add	0, r0, r2
-    rol! r1, r2, r1
+	rol! r1, r2, r1
 	sstore	r0, r1
 	ret
 

--- a/programs/rol_sets_eq_flag.zasm
+++ b/programs/rol_sets_eq_flag.zasm
@@ -1,0 +1,16 @@
+	.text
+	.file	"rol_sets_eq_flag.zasm"
+	.globl	__entry
+__entry:
+
+.func_begin0:
+    ; EQ is set if the result is zero
+	add	0, r0, r1
+	add	0, r0, r2
+    rol! r1, r2, r1
+	sstore	r0, r1
+	ret
+
+.func_end0:
+	.note.GNU-stack
+	.rodata

--- a/programs/rol_stack.zasm
+++ b/programs/rol_stack.zasm
@@ -1,0 +1,17 @@
+	.text
+	.file	"rol_stack.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+	; grow stack
+	add 1, r0, stack+=[2]
+	; set stack value
+	add 1, r0, stack=[0]
+	add	4, r0, r2
+	; left rotation
+	rol stack=[0], r2, r3
+	sstore r0, r3
+	ret
+.func_end0:
+	.note.GNU-stack
+	.rodata

--- a/programs/rol_stack.zasm
+++ b/programs/rol_stack.zasm
@@ -6,10 +6,10 @@ __entry:
 	; grow stack
 	add 1, r0, stack+=[2]
 	; set stack value
-	add 1, r0, stack=[0]
+	add 1, r0, stack[0]
 	add	4, r0, r2
 	; left rotation
-	rol stack=[0], r2, r3
+	rol stack[0], r2, r3
 	sstore r0, r3
 	ret
 .func_end0:

--- a/programs/ror.zasm
+++ b/programs/ror.zasm
@@ -1,0 +1,13 @@
+	.text
+	.file	"ror.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    add	16, r0, r1
+    add 4, r0, r2
+    ror r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+    .note.GNU-stack
+    .rodata

--- a/programs/ror_conditional_eq.zasm
+++ b/programs/ror_conditional_eq.zasm
@@ -1,0 +1,13 @@
+	.text
+	.file	"ror_conditional_eq.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    add	16, r0, r1
+    add 4, r0, r2
+    ror.eq r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+    .note.GNU-stack
+    .rodata

--- a/programs/ror_greater_than_256.zasm
+++ b/programs/ror_greater_than_256.zasm
@@ -1,0 +1,12 @@
+	.text
+	.file	"ror_greater_than_256.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    ; test sets r1 = 16, r2 = 258
+    ror r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+    .note.GNU-stack
+    .rodata

--- a/programs/ror_sets_eq_flag.zasm
+++ b/programs/ror_sets_eq_flag.zasm
@@ -1,0 +1,16 @@
+	.text
+	.file	"ror_sets_eq_flag.zasm"
+	.globl	__entry
+__entry:
+
+.func_begin0:
+    ; EQ is set if the result is zero
+	add	0, r0, r1
+	add	0, r0, r2
+    ror! r1, r2, r1
+	sstore	r0, r1
+	ret
+
+.func_end0:
+	.note.GNU-stack
+	.rodata

--- a/programs/ror_sets_eq_flag.zasm
+++ b/programs/ror_sets_eq_flag.zasm
@@ -4,10 +4,10 @@
 __entry:
 
 .func_begin0:
-    ; EQ is set if the result is zero
+	; EQ is set if the result is zero
 	add	0, r0, r1
 	add	0, r0, r2
-    ror! r1, r2, r1
+	ror! r1, r2, r1
 	sstore	r0, r1
 	ret
 

--- a/programs/ror_stack.zasm
+++ b/programs/ror_stack.zasm
@@ -6,10 +6,10 @@ __entry:
 	; grow stack
 	add 1, r0, stack+=[2]
 	; set stack value
-	add 16, r0, stack=[0]
+	add 16, r0, stack[0]
 	add	4, r0, r2
 	; right rotation
-	ror stack=[0], r2, r3
+	ror stack[0], r2, r3
 	sstore r0, r3
 	ret
 .func_end0:

--- a/programs/ror_stack.zasm
+++ b/programs/ror_stack.zasm
@@ -1,0 +1,17 @@
+	.text
+	.file	"ror_stack.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+	; grow stack
+	add 1, r0, stack+=[2]
+	; set stack value
+	add 16, r0, stack=[0]
+	add	4, r0, r2
+	; right rotation
+	ror stack=[0], r2, r3
+	sstore r0, r3
+	ret
+.func_end0:
+	.note.GNU-stack
+	.rodata

--- a/programs/shl.zasm
+++ b/programs/shl.zasm
@@ -4,11 +4,10 @@
 __entry:
 .func_begin0:
     add	1, r0, r1
-	add 2, r0, r2
+    add 2, r0, r2
     shl r1, r2, r3
     sstore r0, r3
     ret
 .func_end0:
-
-	.note.GNU-stack
-	.rodata
+    .note.GNU-stack
+    .rodata

--- a/programs/shl.zasm
+++ b/programs/shl.zasm
@@ -1,0 +1,14 @@
+	.text
+	.file	"shl.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    add	1, r0, r1
+	add 2, r0, r2
+    shl r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/programs/shl_conditional_eq.zasm
+++ b/programs/shl_conditional_eq.zasm
@@ -3,12 +3,11 @@
 	.globl	__entry
 __entry:
 .func_begin0:
-    add	4, r0, r1
+	add	4, r0, r1
 	add 1, r0, r2
-    shl.eq r1, r2, r3
-    sstore r0, r3
-    ret
+	shl.eq r1, r2, r3
+	sstore r0, r3
+	ret
 .func_end0:
-
 	.note.GNU-stack
 	.rodata

--- a/programs/shl_conditional_eq.zasm
+++ b/programs/shl_conditional_eq.zasm
@@ -1,0 +1,14 @@
+	.text
+	.file	"shl_conditional_eq.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    add	4, r0, r1
+	add 1, r0, r2
+    shl.eq r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/programs/shl_greater_than_256.zasm
+++ b/programs/shl_greater_than_256.zasm
@@ -1,0 +1,12 @@
+	.text
+	.file	"shl_greater_than_256.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    ; test sets r1 = 1, r2 = 258
+    shl r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+    .note.GNU-stack
+    .rodata

--- a/programs/shl_sets_eq_flag.zasm
+++ b/programs/shl_sets_eq_flag.zasm
@@ -4,10 +4,10 @@
 __entry:
 
 .func_begin0:
-    ; EQ is set if the result is zero
+	; EQ is set if the result is zero
 	add	0, r0, r1
 	add	0, r0, r2
-    shl! r1, r2, r1
+	shl! r1, r2, r1
 	sstore	r0, r1
 	ret
 

--- a/programs/shl_sets_eq_flag.zasm
+++ b/programs/shl_sets_eq_flag.zasm
@@ -1,0 +1,16 @@
+	.text
+	.file	"shl_sets_eq_flag.zasm"
+	.globl	__entry
+__entry:
+
+.func_begin0:
+    ; EQ is set if the result is zero
+	add	0, r0, r1
+	add	0, r0, r2
+    shl! r1, r2, r1
+	sstore	r0, r1
+	ret
+
+.func_end0:
+	.note.GNU-stack
+	.rodata

--- a/programs/shl_stack.zasm
+++ b/programs/shl_stack.zasm
@@ -5,14 +5,13 @@ __entry:
 .func_begin0:
 	; grow stack
 	add 1, r0, stack+=[2]
-    ; set stack value
-    add 4, r0, stack=[0]
-    add	2, r0, r2
-    ; shift left
-    shl stack=[0], r2, r3
-    sstore r0, r3
-    ret
+	; set stack value
+	add 4, r0, stack=[0]
+	add	2, r0, r2
+	; shift left
+	shl stack=[0], r2, r3
+	sstore r0, r3
+	ret
 .func_end0:
-
 	.note.GNU-stack
 	.rodata

--- a/programs/shl_stack.zasm
+++ b/programs/shl_stack.zasm
@@ -6,10 +6,10 @@ __entry:
 	; grow stack
 	add 1, r0, stack+=[2]
 	; set stack value
-	add 4, r0, stack=[0]
+	add 4, r0, stack[0]
 	add	2, r0, r2
 	; shift left
-	shl stack=[0], r2, r3
+	shl stack[0], r2, r3
 	sstore r0, r3
 	ret
 .func_end0:

--- a/programs/shl_stack.zasm
+++ b/programs/shl_stack.zasm
@@ -1,0 +1,18 @@
+	.text
+	.file	"shl_stack.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+	; grow stack
+	add 1, r0, stack+=[2]
+    ; set stack value
+    add 4, r0, stack=[0]
+    add	2, r0, r2
+    ; shift left
+    shl stack=[0], r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/programs/shr.zasm
+++ b/programs/shr.zasm
@@ -1,0 +1,14 @@
+	.text
+	.file	"shl.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    add	8, r0, r1
+	add 2, r0, r2
+    shr r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/programs/shr.zasm
+++ b/programs/shr.zasm
@@ -1,5 +1,5 @@
 	.text
-	.file	"shl.zasm"
+	.file	"shr.zasm"
 	.globl	__entry
 __entry:
 .func_begin0:

--- a/programs/shr.zasm
+++ b/programs/shr.zasm
@@ -3,12 +3,11 @@
 	.globl	__entry
 __entry:
 .func_begin0:
-    add	8, r0, r1
+	add	8, r0, r1
 	add 2, r0, r2
-    shr r1, r2, r3
-    sstore r0, r3
-    ret
+	shr r1, r2, r3
+	sstore r0, r3
+	ret
 .func_end0:
-
 	.note.GNU-stack
 	.rodata

--- a/programs/shr_conditional_eq.zasm
+++ b/programs/shr_conditional_eq.zasm
@@ -3,12 +3,11 @@
 	.globl	__entry
 __entry:
 .func_begin0:
-    add	8, r0, r1
+	add	8, r0, r1
 	add 2, r0, r2
-    shr.eq r1, r2, r3
-    sstore r0, r3
-    ret
+	shr.eq r1, r2, r3
+	sstore r0, r3
+	ret
 .func_end0:
-
 	.note.GNU-stack
 	.rodata

--- a/programs/shr_conditional_eq.zasm
+++ b/programs/shr_conditional_eq.zasm
@@ -1,0 +1,14 @@
+	.text
+	.file	"shr_conditional_eq.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+    add	8, r0, r1
+	add 2, r0, r2
+    shr.eq r1, r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/programs/shr_greater_than_256.zasm
+++ b/programs/shr_greater_than_256.zasm
@@ -1,0 +1,12 @@
+	.text
+	.file	"shr_greater_than_256.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+	; test sets r1 = 16, r2 = 258
+	shr r1, r2, r3
+	sstore r0, r3
+	ret
+.func_end0:
+	.note.GNU-stack
+	.rodata

--- a/programs/shr_sets_eq_flag.zasm
+++ b/programs/shr_sets_eq_flag.zasm
@@ -4,10 +4,10 @@
 __entry:
 
 .func_begin0:
-    ; EQ is set if the result is zero
+	; EQ is set if the result is zero
 	add	0, r0, r1
 	add	0, r0, r2
-    shr! r1, r2, r1
+	shr! r1, r2, r1
 	sstore	r0, r1
 	ret
 

--- a/programs/shr_sets_eq_flag.zasm
+++ b/programs/shr_sets_eq_flag.zasm
@@ -1,0 +1,16 @@
+	.text
+	.file	"shr_sets_eq_flag.zasm"
+	.globl	__entry
+__entry:
+
+.func_begin0:
+    ; EQ is set if the result is zero
+	add	0, r0, r1
+	add	0, r0, r2
+    shr! r1, r2, r1
+	sstore	r0, r1
+	ret
+
+.func_end0:
+	.note.GNU-stack
+	.rodata

--- a/programs/shr_stack.zasm
+++ b/programs/shr_stack.zasm
@@ -1,0 +1,18 @@
+	.text
+	.file	"shr_stack.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+	; grow stack
+	add 1, r0, stack+=[2]
+    ; set stack value
+    add 4, r0, stack=[0]
+    add	2, r0, r2
+    ; shift right
+    shr stack=[0], r2, r3
+    sstore r0, r3
+    ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/programs/shr_stack.zasm
+++ b/programs/shr_stack.zasm
@@ -6,10 +6,10 @@ __entry:
     ; grow stack
     add 1, r0, stack+=[2]
     ; set stack value
-    add 4, r0, stack=[0]
+    add 4, r0, stack[0]
     add	2, r0, r2
     ; shift right
-    shr stack=[0], r2, r3
+    shr stack[0], r2, r3
     sstore r0, r3
     ret
 .func_end0:

--- a/programs/shr_stack.zasm
+++ b/programs/shr_stack.zasm
@@ -3,8 +3,8 @@
 	.globl	__entry
 __entry:
 .func_begin0:
-	; grow stack
-	add 1, r0, stack+=[2]
+    ; grow stack
+    add 1, r0, stack+=[2]
     ; set stack value
     add 4, r0, stack=[0]
     add	2, r0, r2
@@ -13,6 +13,5 @@ __entry:
     sstore r0, r3
     ret
 .func_end0:
-
-	.note.GNU-stack
-	.rodata
+    .note.GNU-stack
+    .rodata

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,14 @@ pub fn run_program_with_custom_state(bin_path: &str, mut vm: VMState) -> (U256, 
                 Variant::Div(_) => _div(&mut vm, &opcode),
                 Variant::Jump(_) => todo!(),
                 Variant::Context(_) => todo!(),
-                Variant::Shift(_) => _shift(&mut vm, &opcode),
+                Variant::Shift(_) => _shift(
+                    &mut vm,
+                    &opcode,
+                    match opcode.variant {
+                        Variant::Shift(shift_type) => shift_type,
+                        _ => unreachable!(),
+                    },
+                ),
                 Variant::Binop(_) => todo!(),
                 Variant::Ptr(ptr_variant) => match ptr_variant {
                     PtrOpcode::Add => _ptr_add(&mut vm, &opcode),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod value;
 use op_handlers::add::_add;
 use op_handlers::div::_div;
 use op_handlers::mul::_mul;
+use op_handlers::shift::_shift;
 use op_handlers::sub::_sub;
 pub use opcode::Opcode;
 use state::VMState;
@@ -61,7 +62,7 @@ pub fn run_program_with_custom_state(bin_path: &str, mut vm: VMState) -> (U256, 
                 Variant::Div(_) => _div(&mut vm, &opcode),
                 Variant::Jump(_) => todo!(),
                 Variant::Context(_) => todo!(),
-                Variant::Shift(_) => todo!(),
+                Variant::Shift(_) => _shift(&mut vm, &opcode),
                 Variant::Binop(_) => todo!(),
                 Variant::Ptr(_) => todo!(),
                 Variant::NearCall(_) => todo!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,10 @@ use op_handlers::ptr_add::_ptr_add;
 use op_handlers::ptr_pack::_ptr_pack;
 use op_handlers::ptr_shrink::_ptr_shrink;
 use op_handlers::ptr_sub::_ptr_sub;
-use op_handlers::shift::_shift;
+use op_handlers::shift::_rol;
+use op_handlers::shift::_ror;
+use op_handlers::shift::_shl;
+use op_handlers::shift::_shr;
 use op_handlers::sub::_sub;
 pub use opcode::Opcode;
 use state::VMState;
@@ -22,6 +25,7 @@ use zkevm_opcode_defs::ISAVersion;
 use zkevm_opcode_defs::LogOpcode;
 use zkevm_opcode_defs::Opcode as Variant;
 use zkevm_opcode_defs::PtrOpcode;
+use zkevm_opcode_defs::ShiftOpcode;
 
 /// Run a vm program with a clean VM state.
 pub fn run_program(bin_path: &str) -> (U256, VMState) {
@@ -68,14 +72,13 @@ pub fn run_program_with_custom_state(bin_path: &str, mut vm: VMState) -> (U256, 
                 Variant::Div(_) => _div(&mut vm, &opcode),
                 Variant::Jump(_) => todo!(),
                 Variant::Context(_) => todo!(),
-                Variant::Shift(_) => _shift(
-                    &mut vm,
-                    &opcode,
-                    match opcode.variant {
-                        Variant::Shift(shift_type) => shift_type,
-                        _ => unreachable!(),
-                    },
-                ),
+                Variant::Shift(_) => match opcode.variant {
+                    Variant::Shift(ShiftOpcode::Shl) => _shl(&mut vm, &opcode),
+                    Variant::Shift(ShiftOpcode::Shr) => _shr(&mut vm, &opcode),
+                    Variant::Shift(ShiftOpcode::Rol) => _rol(&mut vm, &opcode),
+                    Variant::Shift(ShiftOpcode::Ror) => _ror(&mut vm, &opcode),
+                    _ => unreachable!(),
+                },
                 Variant::Binop(_) => todo!(),
                 Variant::Ptr(ptr_variant) => match ptr_variant {
                     PtrOpcode::Add => _ptr_add(&mut vm, &opcode),

--- a/src/op_handlers/mod.rs
+++ b/src/op_handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
 pub mod div;
 pub mod mul;
+pub mod shift;
 pub mod sub;

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -34,7 +34,8 @@ fn _shr(vm: &mut VMState, opcode: &Opcode) {
 fn _rol(vm: &mut VMState, opcode: &Opcode) {
     let (mut src0, src1) = address_operands_read(vm, opcode);
     let shift = (src1.low_u32() % 256) as usize;
-    src0.0.rotate_left(shift);
+    let result = (src0 << shift) | (src0 >> (256 - shift));
+    src0 = result;
     if opcode.alters_vm_flags {
         // Eq is set if result == 0
         vm.flag_eq |= src0.is_zero();

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -32,32 +32,31 @@ fn _shr(vm: &mut VMState, opcode: &Opcode) {
 }
 
 fn _rol(vm: &mut VMState, opcode: &Opcode) {
-    let (mut src0, src1) = address_operands_read(vm, opcode);
+    let (src0, src1) = address_operands_read(vm, opcode);
     let shift = (src1.low_u32() % 256) as usize;
     let result = (src0 << shift) | (src0 >> (256 - shift));
-    src0 = result;
     if opcode.alters_vm_flags {
         // Eq is set if result == 0
-        vm.flag_eq |= src0.is_zero();
+        vm.flag_eq |= result.is_zero();
         // other flags are reset
         vm.flag_lt_of = false;
         vm.flag_gt = false;
     }
-    address_operands_store(vm, opcode, src0);
+    address_operands_store(vm, opcode, result);
 }
 
 fn _ror(vm: &mut VMState, opcode: &Opcode) {
-    let (mut src0, src1) = address_operands_read(vm, opcode);
+    let (src0, src1) = address_operands_read(vm, opcode);
     let shift = (src1.low_u32() % 256) as usize;
-    src0.0.rotate_right(shift);
+    let result = (src0 >> shift) | (src0 << (256 - shift));
     if opcode.alters_vm_flags {
         // Eq is set if result == 0
-        vm.flag_eq |= src0.is_zero();
+        vm.flag_eq |= result.is_zero();
         // other flags are reset
         vm.flag_lt_of = false;
         vm.flag_gt = false;
     }
-    address_operands_store(vm, opcode, src0);
+    address_operands_store(vm, opcode, result);
 }
 
 pub fn _shift(vm: &mut VMState, opcode: &Opcode) {

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -1,10 +1,12 @@
 use crate::address_operands::{address_operands_read, address_operands_store};
+use crate::value::TaggedValue;
 use crate::{opcode::Opcode, state::VMState};
 use zkevm_opcode_defs::Opcode as Variant;
 use zkevm_opcode_defs::ShiftOpcode;
 
 fn _shl(vm: &mut VMState, opcode: &Opcode) {
-    let (src0, src1) = address_operands_read(vm, opcode);
+    let (src0_t, src1_t) = address_operands_read(vm, opcode);
+    let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = (src1.low_u32() % 256) as usize;
     let res = src0 << shift;
     if opcode.alters_vm_flags {
@@ -14,11 +16,12 @@ fn _shl(vm: &mut VMState, opcode: &Opcode) {
         vm.flag_lt_of = false;
         vm.flag_gt = false;
     }
-    address_operands_store(vm, opcode, res);
+    address_operands_store(vm, opcode, TaggedValue::new_raw_integer(res));
 }
 
 fn _shr(vm: &mut VMState, opcode: &Opcode) {
-    let (src0, src1) = address_operands_read(vm, opcode);
+    let (src0_t, src1_t) = address_operands_read(vm, opcode);
+    let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = (src1.low_u32() % 256) as usize;
     let res = src0 >> shift;
     if opcode.alters_vm_flags {
@@ -28,11 +31,12 @@ fn _shr(vm: &mut VMState, opcode: &Opcode) {
         vm.flag_lt_of = false;
         vm.flag_gt = false;
     }
-    address_operands_store(vm, opcode, res);
+    address_operands_store(vm, opcode, TaggedValue::new_raw_integer(res));
 }
 
 fn _rol(vm: &mut VMState, opcode: &Opcode) {
-    let (src0, src1) = address_operands_read(vm, opcode);
+    let (src0_t, src1_t) = address_operands_read(vm, opcode);
+    let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = (src1.low_u32() % 256) as usize;
     let result = (src0 << shift) | (src0 >> (256 - shift));
     if opcode.alters_vm_flags {
@@ -42,11 +46,12 @@ fn _rol(vm: &mut VMState, opcode: &Opcode) {
         vm.flag_lt_of = false;
         vm.flag_gt = false;
     }
-    address_operands_store(vm, opcode, result);
+    address_operands_store(vm, opcode, TaggedValue::new_raw_integer(result));
 }
 
 fn _ror(vm: &mut VMState, opcode: &Opcode) {
-    let (src0, src1) = address_operands_read(vm, opcode);
+    let (src0_t, src1_t) = address_operands_read(vm, opcode);
+    let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = (src1.low_u32() % 256) as usize;
     let result = (src0 >> shift) | (src0 << (256 - shift));
     if opcode.alters_vm_flags {
@@ -56,7 +61,7 @@ fn _ror(vm: &mut VMState, opcode: &Opcode) {
         vm.flag_lt_of = false;
         vm.flag_gt = false;
     }
-    address_operands_store(vm, opcode, result);
+    address_operands_store(vm, opcode, TaggedValue::new_raw_integer(result));
 }
 
 pub fn _shift(vm: &mut VMState, opcode: &Opcode) {

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -1,7 +1,6 @@
 use crate::address_operands::{address_operands_read, address_operands_store};
 use crate::value::TaggedValue;
 use crate::{opcode::Opcode, state::VMState};
-use zkevm_opcode_defs::Opcode as Variant;
 use zkevm_opcode_defs::ShiftOpcode;
 
 fn _shl(vm: &mut VMState, opcode: &Opcode) {
@@ -64,12 +63,11 @@ fn _ror(vm: &mut VMState, opcode: &Opcode) {
     address_operands_store(vm, opcode, TaggedValue::new_raw_integer(result));
 }
 
-pub fn _shift(vm: &mut VMState, opcode: &Opcode) {
-    match opcode.variant {
-        Variant::Shift(ShiftOpcode::Shl) => _shl(vm, opcode),
-        Variant::Shift(ShiftOpcode::Shr) => _shr(vm, opcode),
-        Variant::Shift(ShiftOpcode::Rol) => _rol(vm, opcode),
-        Variant::Shift(ShiftOpcode::Ror) => _ror(vm, opcode),
-        _ => panic!("Unsupported shift operation"),
+pub fn _shift(vm: &mut VMState, opcode: &Opcode, shift_type: ShiftOpcode) {
+    match shift_type {
+        ShiftOpcode::Shl => _shl(vm, opcode),
+        ShiftOpcode::Shr => _shr(vm, opcode),
+        ShiftOpcode::Rol => _rol(vm, opcode),
+        ShiftOpcode::Ror => _ror(vm, opcode),
     }
 }

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -5,7 +5,7 @@ use crate::{opcode::Opcode, state::VMState};
 pub fn _shl(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
-    let shift = src1.low_u32() % 256;
+    let shift = src1 % 256;
     let res = src0 << shift;
     if opcode.alters_vm_flags {
         // Eq is set if result == 0
@@ -20,7 +20,7 @@ pub fn _shl(vm: &mut VMState, opcode: &Opcode) {
 pub fn _shr(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
-    let shift = src1.low_u32() % 256;
+    let shift = src1 % 256;
     let res = src0 >> shift;
     if opcode.alters_vm_flags {
         // Eq is set if result == 0

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -6,7 +6,7 @@ use zkevm_opcode_defs::ShiftOpcode;
 fn _shl(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
-    let shift = (src1.low_u32() % 256) as usize;
+    let shift = src1.low_u32() % 256;
     let res = src0 << shift;
     if opcode.alters_vm_flags {
         // Eq is set if result == 0
@@ -21,7 +21,7 @@ fn _shl(vm: &mut VMState, opcode: &Opcode) {
 fn _shr(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
-    let shift = (src1.low_u32() % 256) as usize;
+    let shift = src1.low_u32() % 256;
     let res = src0 >> shift;
     if opcode.alters_vm_flags {
         // Eq is set if result == 0
@@ -36,7 +36,7 @@ fn _shr(vm: &mut VMState, opcode: &Opcode) {
 fn _rol(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
-    let shift = (src1.low_u32() % 256) as usize;
+    let shift = src1.low_u32() % 256;
     let result = (src0 << shift) | (src0 >> (256 - shift));
     if opcode.alters_vm_flags {
         // Eq is set if result == 0
@@ -51,7 +51,7 @@ fn _rol(vm: &mut VMState, opcode: &Opcode) {
 fn _ror(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
-    let shift = (src1.low_u32() % 256) as usize;
+    let shift = src1.low_u32() % 256;
     let result = (src0 >> shift) | (src0 << (256 - shift));
     if opcode.alters_vm_flags {
         // Eq is set if result == 0

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -1,9 +1,8 @@
 use crate::address_operands::{address_operands_read, address_operands_store};
 use crate::value::TaggedValue;
 use crate::{opcode::Opcode, state::VMState};
-use zkevm_opcode_defs::ShiftOpcode;
 
-fn _shl(vm: &mut VMState, opcode: &Opcode) {
+pub fn _shl(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = src1.low_u32() % 256;
@@ -18,7 +17,7 @@ fn _shl(vm: &mut VMState, opcode: &Opcode) {
     address_operands_store(vm, opcode, TaggedValue::new_raw_integer(res));
 }
 
-fn _shr(vm: &mut VMState, opcode: &Opcode) {
+pub fn _shr(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = src1.low_u32() % 256;
@@ -33,7 +32,7 @@ fn _shr(vm: &mut VMState, opcode: &Opcode) {
     address_operands_store(vm, opcode, TaggedValue::new_raw_integer(res));
 }
 
-fn _rol(vm: &mut VMState, opcode: &Opcode) {
+pub fn _rol(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = src1.low_u32() % 256;
@@ -48,7 +47,7 @@ fn _rol(vm: &mut VMState, opcode: &Opcode) {
     address_operands_store(vm, opcode, TaggedValue::new_raw_integer(result));
 }
 
-fn _ror(vm: &mut VMState, opcode: &Opcode) {
+pub fn _ror(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = src1.low_u32() % 256;
@@ -61,13 +60,4 @@ fn _ror(vm: &mut VMState, opcode: &Opcode) {
         vm.flag_gt = false;
     }
     address_operands_store(vm, opcode, TaggedValue::new_raw_integer(result));
-}
-
-pub fn _shift(vm: &mut VMState, opcode: &Opcode, shift_type: ShiftOpcode) {
-    match shift_type {
-        ShiftOpcode::Shl => _shl(vm, opcode),
-        ShiftOpcode::Shr => _shr(vm, opcode),
-        ShiftOpcode::Rol => _rol(vm, opcode),
-        ShiftOpcode::Ror => _ror(vm, opcode),
-    }
 }

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -1,0 +1,70 @@
+use crate::address_operands::{address_operands_read, address_operands_store};
+use crate::{opcode::Opcode, state::VMState};
+use zkevm_opcode_defs::Opcode as Variant;
+use zkevm_opcode_defs::ShiftOpcode;
+
+fn _shl(vm: &mut VMState, opcode: &Opcode) {
+    let (src0, src1) = address_operands_read(vm, opcode);
+    let shift = (src1.low_u32() % 256) as usize;
+    let res = src0 << shift;
+    if opcode.alters_vm_flags {
+        // Eq is set if result == 0
+        vm.flag_eq |= res.is_zero();
+        // other flags are reset
+        vm.flag_lt_of = false;
+        vm.flag_gt = false;
+    }
+    address_operands_store(vm, opcode, res);
+}
+
+fn _shr(vm: &mut VMState, opcode: &Opcode) {
+    let (src0, src1) = address_operands_read(vm, opcode);
+    let shift = (src1.low_u32() % 256) as usize;
+    let res = src0 >> shift;
+    if opcode.alters_vm_flags {
+        // Eq is set if result == 0
+        vm.flag_eq |= res.is_zero();
+        // other flags are reset
+        vm.flag_lt_of = false;
+        vm.flag_gt = false;
+    }
+    address_operands_store(vm, opcode, res);
+}
+
+fn _rol(vm: &mut VMState, opcode: &Opcode) {
+    let (mut src0, src1) = address_operands_read(vm, opcode);
+    let shift = (src1.low_u32() % 256) as usize;
+    src0.0.rotate_left(shift);
+    if opcode.alters_vm_flags {
+        // Eq is set if result == 0
+        vm.flag_eq |= src0.is_zero();
+        // other flags are reset
+        vm.flag_lt_of = false;
+        vm.flag_gt = false;
+    }
+    address_operands_store(vm, opcode, src0);
+}
+
+fn _ror(vm: &mut VMState, opcode: &Opcode) {
+    let (mut src0, src1) = address_operands_read(vm, opcode);
+    let shift = (src1.low_u32() % 256) as usize;
+    src0.0.rotate_right(shift);
+    if opcode.alters_vm_flags {
+        // Eq is set if result == 0
+        vm.flag_eq |= src0.is_zero();
+        // other flags are reset
+        vm.flag_lt_of = false;
+        vm.flag_gt = false;
+    }
+    address_operands_store(vm, opcode, src0);
+}
+
+pub fn _shift(vm: &mut VMState, opcode: &Opcode) {
+    match opcode.variant {
+        Variant::Shift(ShiftOpcode::Shl) => _shl(vm, opcode),
+        Variant::Shift(ShiftOpcode::Shr) => _shr(vm, opcode),
+        Variant::Shift(ShiftOpcode::Rol) => _rol(vm, opcode),
+        Variant::Shift(ShiftOpcode::Ror) => _ror(vm, opcode),
+        _ => panic!("Unsupported shift operation"),
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -509,12 +509,12 @@ fn test_shl_stack() {
     assert_eq!(result, U256::from(16)); // 4 << 2 = 16
 }
 
-// #[test]
-// fn test_shr_stack() {
-//     let bin_path = make_bin_path_asm("shr_stack");
-//     let (result, _) = run_program(&bin_path);
-//     assert_eq!(result, U256::from(1)); // 4 << 1 = 8
-// }
+#[test]
+fn test_shr_stack() {
+    let bin_path = make_bin_path_asm("shr_stack");
+    let (result, _) = run_program(&bin_path);
+    assert_eq!(result, U256::from(1)); // 4 >> 2 = 1
+}
 
 // #[test]
 // fn test_shl_conditional() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -502,12 +502,12 @@ fn test_shr_asm() {
     assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
 }
 
-// #[test]
-// fn test_shl_stack() {
-//     let bin_path = make_bin_path_asm("shl_stack");
-//     let (result, _) = run_program(&bin_path);
-//     assert_eq!(result, U256::from(16)); // 4 << 2 = 16
-// }
+#[test]
+fn test_shl_stack() {
+    let bin_path = make_bin_path_asm("shl_stack");
+    let (result, _) = run_program(&bin_path);
+    assert_eq!(result, U256::from(16)); // 4 << 2 = 16
+}
 
 // #[test]
 // fn test_shr_stack() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -577,3 +577,19 @@ fn test_ror_stack() {
     let (result, _) = run_program(&bin_path);
     assert_eq!(result, U256::from(1)); // 16 ror 4 = 1
 }
+
+#[test]
+fn test_rol_conditional_eq_set() {
+    let bin_path = make_bin_path_asm("rol_conditional_eq");
+    let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
+    let (result, _final_vm_state) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    assert_eq!(result, U256::from(16)); // 1 rol 4 = 16
+}
+
+#[test]
+fn test_ror_conditional_eq_set() {
+    let bin_path = make_bin_path_asm("ror_conditional_eq");
+    let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
+    let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    assert_eq!(result, U256::from(1)); // 16 ror 4 = 1
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -988,6 +988,22 @@ fn test_shl_asm() {
 }
 
 #[test]
+fn test_shl_asm_greater_than_256() {
+    let bin_path = make_bin_path_asm("shl_greater_than_256");
+    let r1 = TaggedValue::new_raw_integer(U256::from(1));
+    let r2 = TaggedValue::new_raw_integer(U256::from(258)); // Shift amount greater than 256
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result.value, U256::from(4)); // (1 << 258) is equivalent to (1 << 2) in a 256-bit context
+}
+
+#[test]
 fn test_shr_asm() {
     let bin_path = make_bin_path_asm("shr");
     let (_, vm) = run_program(&bin_path);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -531,3 +531,19 @@ fn test_shr_conditional_eq_set() {
     let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
     assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
 }
+
+#[test]
+fn test_rol_asm() {
+    let bin_path = make_bin_path_asm("rol");
+    let r1 = U256::from(1);
+    let r2 = U256::from(4);
+    let mut registers: [U256; 15] = [U256::zero(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result, U256::from(16)); // 1 rol 4 = 16
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -563,3 +563,17 @@ fn test_ror_asm() {
 
     assert_eq!(result, U256::from(1)); // 16 ror 4 = 1
 }
+
+#[test]
+fn test_rol_stack() {
+    let bin_path = make_bin_path_asm("rol_stack");
+    let (result, _) = run_program(&bin_path);
+    assert_eq!(result, U256::from(16)); // 1 rol 4 = 16
+}
+
+#[test]
+fn test_ror_stack() {
+    let bin_path = make_bin_path_asm("ror_stack");
+    let (result, _) = run_program(&bin_path);
+    assert_eq!(result, U256::from(1)); // 16 ror 4 = 1
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -469,3 +469,65 @@ fn test_uses_expected_gas() {
     assert_eq!(result, U256::from_dec_str("3").unwrap());
     assert_eq!(final_vm_state.gas_left(), 0_u32);
 }
+
+#[test]
+fn test_shl_asm() {
+    let bin_path = make_bin_path_asm("shl");
+    let r1 = U256::from(1);
+    let r2 = U256::from(2);
+    let mut registers: [U256; 15] = [U256::zero(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result, U256::from(4)); // 1 << 2 = 4
+}
+
+#[test]
+fn test_shr_asm() {
+    let bin_path = make_bin_path_asm("shr");
+    let r1 = U256::from(8);
+    let r2 = U256::from(2);
+    let mut registers: [U256; 15] = [U256::zero(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
+}
+
+#[test]
+fn test_shl_stack() {
+    let bin_path = make_bin_path_asm("shl_stack");
+    let (result, _) = run_program(&bin_path);
+    assert_eq!(result, U256::from(16)); // 4 << 2 = 16
+}
+
+#[test]
+fn test_shr_stack() {
+    let bin_path = make_bin_path_asm("shr_stack");
+    let (result, _) = run_program(&bin_path);
+    assert_eq!(result, U256::from(1)); // 4 << 1 = 8
+}
+
+#[test]
+fn test_shl_conditional() {
+    let bin_path = make_bin_path_asm("shl_conditional");
+    let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
+    let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    assert_eq!(result, U256::from(8)); // 4 << 1 = 8
+}
+
+#[test]
+fn test_shr_conditional() {
+    let bin_path = make_bin_path_asm("shr_conditional");
+    let vm_with_custom_flags = VMStateBuilder::new().gt_flag(true).build();
+    let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -516,18 +516,18 @@ fn test_shr_stack() {
     assert_eq!(result, U256::from(1)); // 4 >> 2 = 1
 }
 
-// #[test]
-// fn test_shl_conditional() {
-//     let bin_path = make_bin_path_asm("shl_conditional");
-//     let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
-//     let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
-//     assert_eq!(result, U256::from(8)); // 4 << 1 = 8
-// }
+#[test]
+fn test_shl_conditional_eq_set() {
+    let bin_path = make_bin_path_asm("shl_conditional_eq");
+    let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
+    let (result, _final_vm_state) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    assert_eq!(result, U256::from(8)); // 4 << 1 = 8
+}
 
-// #[test]
-// fn test_shr_conditional() {
-//     let bin_path = make_bin_path_asm("shr_conditional");
-//     let vm_with_custom_flags = VMStateBuilder::new().gt_flag(true).build();
-//     let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
-//     assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
-// }
+#[test]
+fn test_shr_conditional_eq_set() {
+    let bin_path = make_bin_path_asm("shr_conditional_eq");
+    let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
+    let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -981,14 +981,7 @@ fn test_ptr_pack_in_stack() {
 #[test]
 fn test_shl_asm() {
     let bin_path = make_bin_path_asm("shl");
-    let r1 = TaggedValue::new_raw_integer(U256::from(1));
-    let r2 = TaggedValue::new_raw_integer(U256::from(2));
-    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
-    registers[0] = r1;
-    registers[1] = r2;
-    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
-
-    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let (_, vm) = run_program(&bin_path);
     let result = vm.get_register(3);
 
     assert_eq!(result.value, U256::from(4)); // 1 << 2 = 4
@@ -997,14 +990,7 @@ fn test_shl_asm() {
 #[test]
 fn test_shr_asm() {
     let bin_path = make_bin_path_asm("shr");
-    let r1 = TaggedValue::new_raw_integer(U256::from(8));
-    let r2 = TaggedValue::new_raw_integer(U256::from(2));
-    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
-    registers[0] = r1;
-    registers[1] = r2;
-    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
-
-    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let (_, vm) = run_program(&bin_path);
     let result = vm.get_register(3);
 
     assert_eq!(result.value, U256::from(2)); // 8 >> 2 = 2
@@ -1059,14 +1045,7 @@ fn test_shr_set_eq_flag() {
 #[test]
 fn test_rol_asm() {
     let bin_path = make_bin_path_asm("rol");
-    let r1 = TaggedValue::new_raw_integer(U256::from(1));
-    let r2 = TaggedValue::new_raw_integer(U256::from(4));
-    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
-    registers[0] = r1;
-    registers[1] = r2;
-    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
-
-    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let (_, vm) = run_program(&bin_path);
     let result = vm.get_register(3);
 
     assert_eq!(result.value, U256::from(16)); // 1 rol 4 = 16
@@ -1075,14 +1054,7 @@ fn test_rol_asm() {
 #[test]
 fn test_ror_asm() {
     let bin_path = make_bin_path_asm("ror");
-    let r1 = TaggedValue::new_raw_integer(U256::from(16));
-    let r2 = TaggedValue::new_raw_integer(U256::from(4));
-    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
-    registers[0] = r1;
-    registers[1] = r2;
-    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
-
-    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let (_, vm) = run_program(&bin_path);
     let result = vm.get_register(3);
 
     assert_eq!(result.value, U256::from(1)); // 16 ror 4 = 1

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1148,22 +1148,6 @@ fn test_shl_asm() {
 }
 
 #[test]
-fn test_shl_asm_greater_than_256() {
-    let bin_path = make_bin_path_asm("shl_greater_than_256");
-    let r1 = TaggedValue::new_raw_integer(U256::from(1));
-    let r2 = TaggedValue::new_raw_integer(U256::from(258)); // Shift amount greater than 256
-    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
-    registers[0] = r1;
-    registers[1] = r2;
-    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
-
-    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
-    let result = vm.get_register(3);
-
-    assert_eq!(result.value, U256::from(4)); // (1 << 258) is equivalent to (1 << 2) in a 256-bit context
-}
-
-#[test]
 fn test_shr_asm() {
     let bin_path = make_bin_path_asm("shr");
     let (_, vm) = run_program(&bin_path);
@@ -1280,4 +1264,68 @@ fn test_ror_set_eq_flag() {
     let (_, vm) = run_program(&bin_path);
 
     assert!(vm.flag_eq);
+}
+
+#[test]
+fn test_shl_asm_greater_than_256() {
+    let bin_path = make_bin_path_asm("shl_greater_than_256");
+    let r1 = TaggedValue::new_raw_integer(U256::from(1));
+    let r2 = TaggedValue::new_raw_integer(U256::from(258)); // Shift amount greater than 256
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result.value, U256::from(4)); // 1 >> (258 % 256) = 1 >> 2 = 4
+}
+
+#[test]
+fn test_shr_asm_greater_than_256() {
+    let bin_path = make_bin_path_asm("shr_greater_than_256");
+    let r1 = TaggedValue::new_raw_integer(U256::from(16));
+    let r2 = TaggedValue::new_raw_integer(U256::from(258)); // Shift amount greater than 256
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result.value, U256::from(4)); // 16 >> (258 % 256) = 16 >> 2 = 4
+}
+
+#[test]
+fn test_rol_asm_greater_than_256() {
+    let bin_path = make_bin_path_asm("rol_greater_than_256");
+    let r1 = TaggedValue::new_raw_integer(U256::from(1));
+    let r2 = TaggedValue::new_raw_integer(U256::from(258)); // Shift amount greater than 256
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result.value, U256::from(4)); // 1 rol 258 % 256 = 1 rol 2 = 4
+}
+
+#[test]
+fn test_ror_asm_greater_than_256() {
+    let bin_path = make_bin_path_asm("ror_greater_than_256");
+    let r1 = TaggedValue::new_raw_integer(U256::from(16));
+    let r2 = TaggedValue::new_raw_integer(U256::from(258)); // Shift amount greater than 256
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result.value, U256::from(4)); // 16 ror 258 % 256 = 16 ror 2 = 4
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -547,3 +547,19 @@ fn test_rol_asm() {
 
     assert_eq!(result, U256::from(16)); // 1 rol 4 = 16
 }
+
+#[test]
+fn test_ror_asm() {
+    let bin_path = make_bin_path_asm("ror");
+    let r1 = U256::from(16);
+    let r2 = U256::from(4);
+    let mut registers: [U256; 15] = [U256::zero(); 15];
+    registers[0] = r1;
+    registers[1] = r2;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+
+    let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+    let result = vm.get_register(3);
+
+    assert_eq!(result, U256::from(1)); // 16 ror 4 = 1
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -502,32 +502,32 @@ fn test_shr_asm() {
     assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
 }
 
-#[test]
-fn test_shl_stack() {
-    let bin_path = make_bin_path_asm("shl_stack");
-    let (result, _) = run_program(&bin_path);
-    assert_eq!(result, U256::from(16)); // 4 << 2 = 16
-}
+// #[test]
+// fn test_shl_stack() {
+//     let bin_path = make_bin_path_asm("shl_stack");
+//     let (result, _) = run_program(&bin_path);
+//     assert_eq!(result, U256::from(16)); // 4 << 2 = 16
+// }
 
-#[test]
-fn test_shr_stack() {
-    let bin_path = make_bin_path_asm("shr_stack");
-    let (result, _) = run_program(&bin_path);
-    assert_eq!(result, U256::from(1)); // 4 << 1 = 8
-}
+// #[test]
+// fn test_shr_stack() {
+//     let bin_path = make_bin_path_asm("shr_stack");
+//     let (result, _) = run_program(&bin_path);
+//     assert_eq!(result, U256::from(1)); // 4 << 1 = 8
+// }
 
-#[test]
-fn test_shl_conditional() {
-    let bin_path = make_bin_path_asm("shl_conditional");
-    let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
-    let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
-    assert_eq!(result, U256::from(8)); // 4 << 1 = 8
-}
+// #[test]
+// fn test_shl_conditional() {
+//     let bin_path = make_bin_path_asm("shl_conditional");
+//     let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
+//     let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+//     assert_eq!(result, U256::from(8)); // 4 << 1 = 8
+// }
 
-#[test]
-fn test_shr_conditional() {
-    let bin_path = make_bin_path_asm("shr_conditional");
-    let vm_with_custom_flags = VMStateBuilder::new().gt_flag(true).build();
-    let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
-    assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
-}
+// #[test]
+// fn test_shr_conditional() {
+//     let bin_path = make_bin_path_asm("shr_conditional");
+//     let vm_with_custom_flags = VMStateBuilder::new().gt_flag(true).build();
+//     let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
+//     assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
+// }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -533,6 +533,22 @@ fn test_shr_conditional_eq_set() {
 }
 
 #[test]
+fn test_shl_set_eq_flag() {
+    let bin_path = make_bin_path_asm("shl_sets_eq_flag");
+    let (_, vm) = run_program(&bin_path);
+
+    assert!(vm.flag_eq);
+}
+
+#[test]
+fn test_shr_set_eq_flag() {
+    let bin_path = make_bin_path_asm("shr_sets_eq_flag");
+    let (_, vm) = run_program(&bin_path);
+
+    assert!(vm.flag_eq);
+}
+
+#[test]
 fn test_rol_asm() {
     let bin_path = make_bin_path_asm("rol");
     let r1 = U256::from(1);
@@ -592,4 +608,20 @@ fn test_ror_conditional_eq_set() {
     let vm_with_custom_flags = VMStateBuilder::new().eq_flag(true).build();
     let (result, _) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
     assert_eq!(result, U256::from(1)); // 16 ror 4 = 1
+}
+
+#[test]
+fn test_rol_set_eq_flag() {
+    let bin_path = make_bin_path_asm("rol_sets_eq_flag");
+    let (_, vm) = run_program(&bin_path);
+
+    assert!(vm.flag_eq);
+}
+
+#[test]
+fn test_ror_set_eq_flag() {
+    let bin_path = make_bin_path_asm("ror_sets_eq_flag");
+    let (_, vm) = run_program(&bin_path);
+
+    assert!(vm.flag_eq);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -981,9 +981,9 @@ fn test_ptr_pack_in_stack() {
 #[test]
 fn test_shl_asm() {
     let bin_path = make_bin_path_asm("shl");
-    let r1 = U256::from(1);
-    let r2 = U256::from(2);
-    let mut registers: [U256; 15] = [U256::zero(); 15];
+    let r1 = TaggedValue::new_raw_integer(U256::from(1));
+    let r2 = TaggedValue::new_raw_integer(U256::from(2));
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
     registers[0] = r1;
     registers[1] = r2;
     let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
@@ -991,15 +991,15 @@ fn test_shl_asm() {
     let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
     let result = vm.get_register(3);
 
-    assert_eq!(result, U256::from(4)); // 1 << 2 = 4
+    assert_eq!(result.value, U256::from(4)); // 1 << 2 = 4
 }
 
 #[test]
 fn test_shr_asm() {
     let bin_path = make_bin_path_asm("shr");
-    let r1 = U256::from(8);
-    let r2 = U256::from(2);
-    let mut registers: [U256; 15] = [U256::zero(); 15];
+    let r1 = TaggedValue::new_raw_integer(U256::from(8));
+    let r2 = TaggedValue::new_raw_integer(U256::from(2));
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
     registers[0] = r1;
     registers[1] = r2;
     let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
@@ -1007,7 +1007,7 @@ fn test_shr_asm() {
     let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
     let result = vm.get_register(3);
 
-    assert_eq!(result, U256::from(2)); // 8 >> 2 = 2
+    assert_eq!(result.value, U256::from(2)); // 8 >> 2 = 2
 }
 
 #[test]
@@ -1059,9 +1059,9 @@ fn test_shr_set_eq_flag() {
 #[test]
 fn test_rol_asm() {
     let bin_path = make_bin_path_asm("rol");
-    let r1 = U256::from(1);
-    let r2 = U256::from(4);
-    let mut registers: [U256; 15] = [U256::zero(); 15];
+    let r1 = TaggedValue::new_raw_integer(U256::from(1));
+    let r2 = TaggedValue::new_raw_integer(U256::from(4));
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
     registers[0] = r1;
     registers[1] = r2;
     let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
@@ -1069,15 +1069,15 @@ fn test_rol_asm() {
     let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
     let result = vm.get_register(3);
 
-    assert_eq!(result, U256::from(16)); // 1 rol 4 = 16
+    assert_eq!(result.value, U256::from(16)); // 1 rol 4 = 16
 }
 
 #[test]
 fn test_ror_asm() {
     let bin_path = make_bin_path_asm("ror");
-    let r1 = U256::from(16);
-    let r2 = U256::from(4);
-    let mut registers: [U256; 15] = [U256::zero(); 15];
+    let r1 = TaggedValue::new_raw_integer(U256::from(16));
+    let r2 = TaggedValue::new_raw_integer(U256::from(4));
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
     registers[0] = r1;
     registers[1] = r2;
     let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
@@ -1085,7 +1085,7 @@ fn test_ror_asm() {
     let (_, vm) = run_program_with_custom_state(&bin_path, vm_with_custom_flags);
     let result = vm.get_register(3);
 
-    assert_eq!(result, U256::from(1)); // 16 ror 4 = 1
+    assert_eq!(result.value, U256::from(1)); // 16 ror 4 = 1
 }
 
 #[test]


### PR DESCRIPTION
### Implementing `Shift` Instructions

#### Overview

This PR introduces the implementation and comprehensive testing for four bitwise shift and rotate operations: `Shl` (Shift Left), `Shr` (Shift Right), `Rol` (Rotate Left), and `Ror` (Rotate Right). 

#### Progress and Testing Details

Each instruction (`Shl`, `Shr`, `Rol`, `Ror`) has the following:

- **Implementation** (`shift.rs`): Defines the operation's behavior, either shifting or rotating bits. 
- **Tests** (`integration_test.rs`):
  - `test_<op>_asm()`: Verifies basic functionality using assembly code.
  - `test_<op>_stack()`: Checks the operation with stack-based addressing.
  - `test_<op>_conditional_eq_set()`: Confirms the operation sets the EQ flag.
  - `test_<op>_set_eq_flag()`: Ensures the EQ flag is set correctly for edge cases where the result is zero.
  -  `test_<op>_asm_greater_than_256()`: Checks what happens when shifting with amounts greater than 256.

#### Conclusion

This PR ensures that the shift and rotate operations (`Shl`, `Shr`, `Rol`, `Ror`) are implemented and tested across various scenarios. 