### PR TITLE
Fix: Ptr OpCodes not applying flags correctly

### DIFF
--- a/programs/add_ptr_with_swap.zasm
+++ b/programs/add_ptr_with_swap.zasm
@@ -1,0 +1,13 @@
+	.text
+	.file	"add_ptr_with_swap.zasm"
+	.globl	__entry
+__entry:
+.func_begin0:
+	; sets r1=FatPointer from test
+	ptr.add.s	5, r1, r3
+	sstore	r0, r3
+	ret
+.func_end0:
+
+	.note.GNU-stack
+	.rodata

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -53,7 +53,10 @@ impl Opcode {
         // First 11 bits
         let variant_bits = raw_op & 2047;
         let opcode_zksync = opcode_table[variant_bits as usize];
-        let [alters_vm_flags, swap_flag] = opcode_zksync.flags;
+        let [alters_vm_flags, swap_flag] = match opcode_zksync.opcode {
+            Variant::Ptr(_) => [false, opcode_zksync.flags[0]],
+            _ => opcode_zksync.flags,
+        };
         let predicate_u8: u8 = ((raw_op & 0xe000) >> 13) as u8;
         let src0_and_1_index: u8 = ((raw_op & 0xff0000) >> 16) as u8;
         let dst0_and_1_index: u8 = ((raw_op & 0xff000000) >> 24) as u8;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -735,6 +735,19 @@ fn test_ptr_add() {
 }
 
 #[test]
+fn test_ptr_add_with_swap() {
+    let bin_path = make_bin_path_asm("add_ptr_with_swap");
+    let ptr = FatPointer::default();
+    let r1 = TaggedValue::new_pointer(ptr.encode());
+    let mut registers: [TaggedValue; 15] = [TaggedValue::default(); 15];
+    registers[0] = r1;
+    let vm_with_custom_flags = VMStateBuilder::new().with_registers(registers).build();
+    let (result, _) = run_program(&bin_path, vm_with_custom_flags, &mut []);
+    let new_ptr = FatPointer::decode(result);
+    assert_eq!(new_ptr.offset, 5);
+}
+
+#[test]
 fn test_ptr_add_initial_offset() {
     let bin_path = make_bin_path_asm("add_ptr");
     let ptr = FatPointer {


### PR DESCRIPTION
Closes #67 

[Spec documentation on Ptr Opcodes and their only flag seteable (`mod_swap`)](https://matter-labs.github.io/eravm-spec/spec.html#OpPtrAdd).