### PR TITLE
Connecting execution output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,10 @@ use op_handlers::sub::sub;
 use op_handlers::xor::xor;
 pub use opcode::Opcode;
 use state::VMState;
-use store::{Storage, StorageKey};
+use store::Storage;
 use tracers::tracer::Tracer;
 use u256::U256;
+use value::FatPointer;
 use zkevm_opcode_defs::definitions::synthesize_opcode_decoding_tables;
 use zkevm_opcode_defs::BinopOpcode;
 use zkevm_opcode_defs::ContextOpcode;
@@ -58,6 +59,13 @@ use zkevm_opcode_defs::PtrOpcode;
 use zkevm_opcode_defs::RetOpcode;
 use zkevm_opcode_defs::ShiftOpcode;
 use zkevm_opcode_defs::UMAOpcode;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutionOutput {
+    Ok(Vec<u8>),
+    Revert(Vec<u8>),
+    Panic,
+}
 
 /// Run a vm program from the given path using a custom state.
 /// Returns the value stored at storage with key 0 and the final vm state.
@@ -78,11 +86,14 @@ pub fn program_from_file(bin_path: &str) -> Vec<U256> {
 }
 
 /// Run a vm program with a given bytecode.
-pub fn run_program_with_custom_bytecode(vm: VMState, storage: &mut dyn Storage) -> (U256, VMState) {
+pub fn run_program_with_custom_bytecode(
+    vm: VMState,
+    storage: &mut dyn Storage,
+) -> (ExecutionOutput, VMState) {
     run_opcodes(vm, storage)
 }
 
-fn run_opcodes(vm: VMState, storage: &mut dyn Storage) -> (U256, VMState) {
+fn run_opcodes(vm: VMState, storage: &mut dyn Storage) -> (ExecutionOutput, VMState) {
     run(vm, storage, &mut [])
 }
 
@@ -91,7 +102,7 @@ pub fn run_program(
     vm: VMState,
     storage: &mut dyn Storage,
     tracers: &mut [Box<&mut dyn Tracer>],
-) -> (U256, VMState) {
+) -> (ExecutionOutput, VMState) {
     run(vm, storage, tracers)
 }
 
@@ -99,7 +110,7 @@ pub fn run(
     mut vm: VMState,
     storage: &mut dyn Storage,
     tracers: &mut [Box<&mut dyn Tracer>],
-) -> (U256, VMState) {
+) -> (ExecutionOutput, VMState) {
     let opcode_table = synthesize_opcode_decoding_tables(11, ISAVersion(2));
     let contract_address = vm.current_frame().contract_address;
     loop {
@@ -189,13 +200,13 @@ pub fn run(
                     RetOpcode::Revert => {
                         let should_break = revert(&mut vm, &opcode);
                         if should_break {
-                            panic!("Contract Reverted");
+                            return (ExecutionOutput::Revert(vec![]), vm);
                         }
                     }
                     RetOpcode::Panic => {
                         let should_break = panic(&mut vm, &opcode);
                         if should_break {
-                            panic!("Contract Panicked");
+                            return (ExecutionOutput::Panic, vm);
                         }
                     }
                 },
@@ -213,13 +224,19 @@ pub fn run(
         }
         vm.current_frame_mut().pc = opcode_pc_set(&opcode, vm.current_frame().pc);
     }
-
-    let storage_key_zero = StorageKey::new(contract_address, U256::zero());
-    let final_storage_value = match storage.storage_read(storage_key_zero) {
-        Some(value) => value,
-        None => U256::zero(),
-    };
-    (final_storage_value, vm)
+    let fat_pointer_src0 = FatPointer::decode(vm.registers[0].value);
+    let range = fat_pointer_src0.start..fat_pointer_src0.start + fat_pointer_src0.len;
+    let mut result: Vec<u8> = vec![0; range.len()];
+    let end: u32 = (range.end).min(
+        (vm.heaps.get(fat_pointer_src0.page).unwrap().len())
+            .try_into()
+            .unwrap(),
+    );
+    for (i, j) in (range.start..end).enumerate() {
+        let current_heap = vm.heaps.get(fat_pointer_src0.page).unwrap();
+        result[i] = current_heap.read_byte(j);
+    }
+    (ExecutionOutput::Ok(result), vm)
 }
 
 // Set the next PC according to th enext opcode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub fn run(
     let contract_address = vm.current_frame().contract_address;
     loop {
         let opcode = vm.get_opcode(&opcode_table);
-        dbg!(opcode.clone());
+        // dbg!(opcode.clone());
         // dbg!(contract_address);
         for tracer in tracers.iter_mut() {
             tracer.before_execution(&opcode, &mut vm, storage);

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -44,7 +44,7 @@ impl PointerSource {
         }
     }
 }
-pub fn pointer_from_call_data(
+pub fn get_forward_memory_pointer(
     source: U256,
     vm: &mut VMState,
     is_pointer: bool,
@@ -103,7 +103,7 @@ fn far_call_params_from_register(source: TaggedValue, vm: &mut VMState) -> FarCa
     source.to_little_endian(&mut args);
     let [.., shard_id, constructor_call_byte, system_call_byte] = args;
 
-    let Some(forward_memory) = pointer_from_call_data(source, vm, is_pointer) else {
+    let Some(forward_memory) = get_forward_memory_pointer(source, vm, is_pointer) else {
         todo!("Implement panic routing for non-valid forwarded memory")
     };
 

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -26,6 +26,7 @@ struct FarCallParams {
 const FAR_CALL_GAS_SCALAR_MODIFIER: u32 = 63 / 64;
 
 #[repr(u8)]
+#[derive(Debug, Clone, Copy)]
 enum PointerSource {
     /// A new pointer for the heap
     NewForHeap = 0,
@@ -43,7 +44,11 @@ impl PointerSource {
         }
     }
 }
-fn pointer_from_call_data(source: U256, vm: &mut VMState, is_pointer: bool) -> Option<FatPointer> {
+pub fn pointer_from_call_data(
+    source: U256,
+    vm: &mut VMState,
+    is_pointer: bool,
+) -> Option<FatPointer> {
     let pointer_kind = PointerSource::from_abi((source.0[3] >> 32) as u8);
     let mut pointer = FatPointer::decode(source);
     match pointer_kind {
@@ -65,20 +70,24 @@ fn pointer_from_call_data(source: U256, vm: &mut VMState, is_pointer: bool) -> O
             }
 
             match pointer_kind {
-                PointerSource::NewForHeap => vm
-                    .heaps
-                    .get_mut(vm.current_frame().heap_id)
-                    .unwrap()
-                    .expand_memory(bound),
-                PointerSource::NewForAuxHeap => vm
-                    .heaps
-                    .get_mut(vm.current_frame().aux_heap_id)
-                    .unwrap()
-                    .expand_memory(pointer.start + pointer.len),
+                PointerSource::NewForHeap => {
+                    vm.heaps
+                        .get_mut(vm.current_frame().heap_id)
+                        .unwrap()
+                        .expand_memory(bound);
+                    pointer.page = vm.current_frame().heap_id;
+                }
+                PointerSource::NewForAuxHeap => {
+                    vm.heaps
+                        .get_mut(vm.current_frame().aux_heap_id)
+                        .unwrap()
+                        .expand_memory(pointer.start + pointer.len);
+                    pointer.page = vm.current_frame().aux_heap_id;
+                }
                 _ => unreachable!(),
             };
         }
-    }
+    };
     Some(pointer)
 }
 fn far_call_params_from_register(source: TaggedValue, vm: &mut VMState) -> FarCallParams {

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -9,7 +9,7 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) {
     }
     let pointer = FatPointer::decode(src0.value);
 
-    dbg!(pointer.page);
+    // dbg!(pointer.page);
 
     if pointer.offset < pointer.len {
         let mut heap = vm.heaps.get_mut(pointer.page).unwrap();

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -12,15 +12,10 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) {
     dbg!(pointer.page);
 
     if pointer.offset < pointer.len {
-        
-        let mut heap = vm
-            .heaps
-            .get_mut(pointer.page)
-            .unwrap();
-        
+        let mut heap = vm.heaps.get_mut(pointer.page).unwrap();
+
         let gas_cost = heap.expand_memory(pointer.start + pointer.offset + 32);
-        let value = heap
-            .read_from_pointer(&pointer);
+        let value = heap.read_from_pointer(&pointer);
         vm.current_frame_mut().gas_left -= gas_cost;
 
         vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));

--- a/src/op_handlers/ok.rs
+++ b/src/op_handlers/ok.rs
@@ -1,5 +1,5 @@
 use crate::{
-    op_handlers::far_call::pointer_from_call_data,
+    op_handlers::far_call::get_forward_memory_pointer,
     state::VMState,
     value::{FatPointer, TaggedValue},
     Opcode,
@@ -29,7 +29,7 @@ pub fn ok(vm: &mut VMState, opcode: &Opcode) -> bool {
         false
     } else {
         let register = vm.get_register(opcode.src0_index);
-        let result = pointer_from_call_data(register.value, vm, register.is_pointer);
+        let result = get_forward_memory_pointer(register.value, vm, register.is_pointer);
         vm.set_register(
             opcode.src0_index,
             TaggedValue::new_pointer(FatPointer::encode(&result.unwrap())),

--- a/src/op_handlers/ok.rs
+++ b/src/op_handlers/ok.rs
@@ -1,4 +1,9 @@
-use crate::{state::VMState, value::FatPointer, Opcode};
+use crate::{
+    op_handlers::far_call::pointer_from_call_data,
+    state::VMState,
+    value::{FatPointer, TaggedValue},
+    Opcode,
+};
 
 pub fn ok(vm: &mut VMState, opcode: &Opcode) -> bool {
     vm.flag_eq = false;
@@ -23,8 +28,12 @@ pub fn ok(vm: &mut VMState, opcode: &Opcode) -> bool {
         }
         false
     } else {
-        dbg!(vm.registers[0]);
-        dbg!(FatPointer::decode(vm.registers[0].value));
+        let register = vm.get_register(opcode.src0_index);
+        let result = pointer_from_call_data(register.value, vm, register.is_pointer);
+        vm.set_register(
+            opcode.src0_index,
+            TaggedValue::new_pointer(FatPointer::encode(&result.unwrap())),
+        );
         true
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -410,11 +410,7 @@ impl Stack {
     }
 
     pub fn store_with_offset(&mut self, offset: usize, value: TaggedValue) {
-        let sp = self.sp();
-        if offset > sp || offset == 0 {
-            panic!("Trying to store outside of stack bounds");
-        }
-        self.stack[sp - offset] = value;
+        self.store_absolute(self.sp() + offset, value);
     }
 
     pub fn store_absolute(&mut self, index: usize, value: TaggedValue) {
@@ -463,6 +459,10 @@ impl Heap {
             result |= U256::from(self.heap[address as usize + (31 - i)]) << (i * 8);
         }
         result
+    }
+
+    pub fn read_byte(&self, address: u32) -> u8 {
+        self.heap[address as usize]
     }
 
     pub fn read_from_pointer(&self, pointer: &FatPointer) -> U256 {


### PR DESCRIPTION
Now returns the contents of the heap pointed to by `src0` when it is a **far call**. EraVM now returns `ExecutionOutput` enum, to handle panic and reverts.