### PR TITLE
Add event opcode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,6 @@ pub fn run(
         }
         let gas_underflows = vm.decrease_gas(opcode.variant.ergs_price());
         if vm.predicate_holds(&opcode.predicate) {
-            println!("opcode executed");
             match opcode.variant {
                 // TODO: Properly handle what happens
                 // when the VM runs out of ergs/gas.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use op_handlers::context::{
     set_context_u128, sp, this,
 };
 use op_handlers::div::div;
+use op_handlers::event::event;
 use op_handlers::far_call::far_call;
 use op_handlers::fat_pointer_read::fat_pointer_read;
 use op_handlers::heap_read::heap_read;
@@ -117,13 +118,14 @@ pub fn run(
     loop {
         let opcode = vm.get_opcode(&opcode_table);
         // dbg!(&vm.current_frame().pc);
-        // dbg!(opcode.clone());
+        //dbg!(opcode.clone().variant);
         // dbg!(contract_address);
         for tracer in tracers.iter_mut() {
             tracer.before_execution(&opcode, &mut vm, storage);
         }
         let gas_underflows = vm.decrease_gas(opcode.variant.ergs_price());
         if vm.predicate_holds(&opcode.predicate) {
+            println!("opcode executed");
             match opcode.variant {
                 // TODO: Properly handle what happens
                 // when the VM runs out of ergs/gas.
@@ -187,7 +189,7 @@ pub fn run(
                     LogOpcode::StorageRead => storage_read(&mut vm, &opcode, storage),
                     LogOpcode::StorageWrite => storage_write(&mut vm, &opcode, storage),
                     LogOpcode::ToL1Message => todo!(),
-                    LogOpcode::Event => todo!(),
+                    LogOpcode::Event => event(&mut vm, &opcode),
                     LogOpcode::PrecompileCall => todo!(),
                     LogOpcode::Decommit => todo!(),
                     LogOpcode::TransientStorageRead => transient_storage_read(&mut vm, &opcode),

--- a/src/op_handlers/event.rs
+++ b/src/op_handlers/event.rs
@@ -2,7 +2,9 @@ use u256::H160;
 use zkevm_opcode_defs::ADDRESS_EVENT_WRITER;
 
 use crate::{
-    eravm_error::EraVmError, state::{Event, VMState}, Opcode
+    eravm_error::EraVmError,
+    state::{Event, VMState},
+    Opcode,
 };
 
 pub fn event(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
@@ -17,7 +19,7 @@ pub fn event(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
             shard_id: 1, // TODO: Shard Ids are not yet implemented
             tx_number: vm.tx_number as u16,
         };
-    
+
         vm.events.push(event);
     }
     Ok(())

--- a/src/op_handlers/event.rs
+++ b/src/op_handlers/event.rs
@@ -1,18 +1,23 @@
+use u256::H160;
+use zkevm_opcode_defs::ADDRESS_EVENT_WRITER;
+
 use crate::{
     state::{Event, VMState},
     Opcode,
 };
 
 pub fn event(vm: &mut VMState, opcode: &Opcode) {
-    let key = vm.get_register(opcode.src0_index).value;
-    let value = vm.get_register(opcode.src1_index).value;
-    let event = Event {
-        key,
-        value,
-        is_first: opcode.alters_vm_flags,
-        shard_id: 1, // TODO: Shard Ids are not yet implemented
-        tx_number: vm.tx_number as u16,
-    };
-
-    vm.events.push(event);
+    if vm.current_frame().contract_address == H160::from_low_u64_be(ADDRESS_EVENT_WRITER as u64) {
+        let key = vm.get_register(opcode.src0_index).value;
+        let value = vm.get_register(opcode.src1_index).value;
+        let event = Event {
+            key,
+            value,
+            is_first: opcode.alters_vm_flags,
+            shard_id: 1, // TODO: Shard Ids are not yet implemented
+            tx_number: vm.tx_number as u16,
+        };
+    
+        vm.events.push(event);
+    }
 }

--- a/src/op_handlers/event.rs
+++ b/src/op_handlers/event.rs
@@ -1,0 +1,18 @@
+use crate::{
+    state::{Event, VMState},
+    Opcode,
+};
+
+pub fn event(vm: &mut VMState, opcode: &Opcode) {
+    let key = vm.get_register(opcode.src0_index).value;
+    let value = vm.get_register(opcode.src1_index).value;
+    let event = Event {
+        key,
+        value,
+        is_first: opcode.alters_vm_flags,
+        shard_id: 1, // TODO: Shard Ids are not yet implemented
+        tx_number: vm.tx_number as u16,
+    };
+
+    vm.events.push(event);
+}

--- a/src/op_handlers/event.rs
+++ b/src/op_handlers/event.rs
@@ -2,12 +2,12 @@ use u256::H160;
 use zkevm_opcode_defs::ADDRESS_EVENT_WRITER;
 
 use crate::{
-    state::{Event, VMState},
-    Opcode,
+    eravm_error::EraVmError, state::{Event, VMState}, Opcode
 };
 
-pub fn event(vm: &mut VMState, opcode: &Opcode) {
-    if vm.current_frame().contract_address == H160::from_low_u64_be(ADDRESS_EVENT_WRITER as u64) {
+pub fn event(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
+    dbg!(&vm.current_frame()?.contract_address);
+    if vm.current_frame()?.contract_address == H160::from_low_u64_be(ADDRESS_EVENT_WRITER as u64) {
         let key = vm.get_register(opcode.src0_index).value;
         let value = vm.get_register(opcode.src1_index).value;
         let event = Event {
@@ -20,4 +20,5 @@ pub fn event(vm: &mut VMState, opcode: &Opcode) {
     
         vm.events.push(event);
     }
+    Ok(())
 }

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -103,7 +103,8 @@ fn far_call_params_from_register(
     let gas_left = vm.gas_left()?;
 
     if ergs_passed > gas_left {
-        ergs_passed = (gas_left * FAR_CALL_GAS_SCALAR_MODIFIER_DIVIDEND) / FAR_CALL_GAS_SCALAR_MODIFIER_DIVISOR;
+        ergs_passed = (gas_left * FAR_CALL_GAS_SCALAR_MODIFIER_DIVIDEND)
+            / FAR_CALL_GAS_SCALAR_MODIFIER_DIVISOR;
     }
     source.to_little_endian(&mut args);
     let [.., shard_id, constructor_call_byte, system_call_byte] = args;

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -23,7 +23,8 @@ struct FarCallParams {
     /// If the far call is in kernel mode.
     to_system: bool,
 }
-const FAR_CALL_GAS_SCALAR_MODIFIER: u32 = 63 / 64;
+const FAR_CALL_GAS_SCALAR_MODIFIER_DIVIDEND: u32 = 63;
+const FAR_CALL_GAS_SCALAR_MODIFIER_DIVISOR: u32 = 64;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy)]
@@ -102,7 +103,7 @@ fn far_call_params_from_register(
     let gas_left = vm.gas_left()?;
 
     if ergs_passed > gas_left {
-        ergs_passed = gas_left * (FAR_CALL_GAS_SCALAR_MODIFIER);
+        ergs_passed = (gas_left * FAR_CALL_GAS_SCALAR_MODIFIER_DIVIDEND) / FAR_CALL_GAS_SCALAR_MODIFIER_DIVISOR;
     }
     source.to_little_endian(&mut args);
     let [.., shard_id, constructor_call_byte, system_call_byte] = args;

--- a/src/op_handlers/mod.rs
+++ b/src/op_handlers/mod.rs
@@ -4,6 +4,7 @@ pub mod aux_heap_read;
 pub mod aux_heap_write;
 pub mod context;
 pub mod div;
+pub mod event;
 pub mod far_call;
 pub mod fat_pointer_read;
 pub mod heap_read;

--- a/src/state.rs
+++ b/src/state.rs
@@ -38,6 +38,7 @@ pub struct VMStateBuilder {
     pub program: Vec<U256>,
     pub tx_number: u64,
     pub heaps: Heaps,
+    pub events: Vec<Event>,
 }
 
 // On this specific struct, I prefer to have the actual values
@@ -54,6 +55,7 @@ impl Default for VMStateBuilder {
             program: vec![],
             tx_number: 0,
             heaps: Heaps::default(),
+            events: vec![],
         }
     }
 }
@@ -101,6 +103,11 @@ impl VMStateBuilder {
         self
     }
 
+    pub fn with_events(mut self, events: Vec<Event>) -> VMStateBuilder {
+        self.events = events;
+        self
+    }
+
     pub fn build(self) -> VMState {
         VMState {
             registers: self.registers,
@@ -111,6 +118,7 @@ impl VMStateBuilder {
             program: self.program,
             tx_number: self.tx_number,
             heaps: self.heaps,
+            events: self.events,
         }
     }
 }
@@ -129,6 +137,7 @@ pub struct VMState {
     pub program: Vec<U256>,
     pub tx_number: u64,
     pub heaps: Heaps,
+    pub events: Vec<Event>,
 }
 
 // Totally arbitrary, probably we will have to change it later.
@@ -172,6 +181,7 @@ impl VMState {
             program: program_code,
             tx_number: 0,
             heaps,
+            events: vec![],
         }
     }
 
@@ -483,4 +493,13 @@ impl Heap {
     pub fn is_empty(&self) -> bool {
         self.heap.is_empty()
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct Event {
+    pub key: U256,
+    pub value: U256,
+    pub is_first: bool,
+    pub shard_id: u8,
+    pub tx_number: u16,
 }


### PR DESCRIPTION
This PR adds the Event Opcode
Related to https://github.com/lambdaclass/era-compiler-tester/pull/3
It fixes the following tests (with mode Y+M3B3 0.8.26):
```
tests/solidity/simple/yul_instructions/codesize.sol
tests/solidity/simple/yul_instructions/codecopy.sol
tests/solidity/simple/yul_instructions/basefee.sol
tests/solidity/simple/yul_instructions/chainid.sol
tests/solidity/simple/yul_instructions/coinbase.sol
tests/solidity/simple/yul_instructions/gaslimit.sol
tests/solidity/simple/yul_instructions/gasprice.sol
tests/solidity/simple/yul_instructions/number.sol
tests/solidity/simple/yul_instructions/origin.sol
tests/solidity/simple/yul_instructions/prevrandao.sol
tests/solidity/simple/yul_instructions/timestamp.sol
```

