### PR TITLE
Fix smod and sdiv

### DIFF
--- a/src/op_handlers/div.rs
+++ b/src/op_handlers/div.rs
@@ -8,14 +8,27 @@ use crate::{opcode::Opcode, state::VMState};
 pub fn div(vm: &mut VMState, opcode: &Opcode) {
     let (src0_t, src1_t) = address_operands_read(vm, opcode);
     let (src0, src1) = (src0_t.value, src1_t.value);
-    let (quotient, remainder) = src0.div_mod(src1);
-    if opcode.alters_vm_flags {
-        // Lt overflow is cleared
-        vm.flag_lt_of = false;
-        // Eq is set if quotient is zero
-        vm.flag_eq = quotient.is_zero();
-        // Gt is set if the remainder is zero
-        vm.flag_gt = remainder.is_zero();
+    let mut quotient = U256::zero();
+    let mut remainder = U256::zero();
+    if src1.is_zero() {
+        if opcode.alters_vm_flags {
+            // Lt overflow is set
+            vm.flag_lt_of = true;
+            // Eq is set if resultlow is 0, in this case its always 0
+            vm.flag_eq = true;
+            // Gt is set if LT_OF and EQ are cleared, they are not
+            vm.flag_gt = false;
+        }
+    } else {
+        (quotient, remainder) = src0.div_mod(src1);
+        if opcode.alters_vm_flags {
+            // Lt overflow is cleared
+            vm.flag_lt_of = false;
+            // Eq is set if quotient is zero
+            vm.flag_eq = quotient.is_zero();
+            // Gt is set if the remainder is zero
+            vm.flag_gt = remainder.is_zero();
+        }
     }
 
     address_operands_div_mul(

--- a/src/op_handlers/div.rs
+++ b/src/op_handlers/div.rs
@@ -1,3 +1,6 @@
+
+use u256::U256;
+
 use crate::address_operands::{address_operands_div_mul, address_operands_read};
 use crate::value::TaggedValue;
 use crate::{opcode::Opcode, state::VMState};
@@ -9,10 +12,10 @@ pub fn div(vm: &mut VMState, opcode: &Opcode) {
     if opcode.alters_vm_flags {
         // Lt overflow is cleared
         vm.flag_lt_of = false;
-        // Eq is set if quotient is not zero
-        vm.flag_eq = !quotient.is_zero();
-        // Gt is set if the remainder is not zero
-        vm.flag_gt = !remainder.is_zero();
+        // Eq is set if quotient is zero
+        vm.flag_eq = quotient.is_zero();
+        // Gt is set if the remainder is zero
+        vm.flag_gt = remainder.is_zero();
     }
 
     address_operands_div_mul(

--- a/src/op_handlers/div.rs
+++ b/src/op_handlers/div.rs
@@ -1,4 +1,3 @@
-
 use u256::U256;
 
 use crate::address_operands::{address_operands_div_mul, address_operands_read};


### PR DESCRIPTION
This PR fixes the smod and sdiv tests

On the formal specification, the div opcode states:
```
Flags are computed as follows:
◦ LT_OF is cleared;
◦ EQ is set if the quotient is not zero;
◦ GT is set if the reminder is not zero.
```

However, on both the vm2 and zk-evm, EQ and GT are set if quotient and reminder are 0, respectively.