### PR TITLE
Fix return tests

### DIFF
--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -47,6 +47,7 @@ impl Context {
         heap_id: u32,
         aux_heap_id: u32,
         calldata_heap_id: u32,
+        exception_handler: u64
     ) -> Self {
         Self {
             frame: CallFrame::new_far_call_frame(
@@ -56,6 +57,7 @@ impl Context {
                 heap_id,
                 aux_heap_id,
                 calldata_heap_id,
+                exception_handler
             ),
             near_call_frames: vec![],
             contract_address,
@@ -74,6 +76,7 @@ impl CallFrame {
         heap_id: u32,
         aux_heap_id: u32,
         calldata_heap_id: u32,
+        exception_handler: u64
     ) -> Self {
         Self {
             stack: Stack::new(),
@@ -84,7 +87,7 @@ impl CallFrame {
             pc: 0,
             gas_left: Saturating(gas_stipend),
             transient_storage: Box::new(InMemory::new_empty()),
-            exception_handler: 0,
+            exception_handler,
             contract_address,
         }
     }

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -39,6 +39,7 @@ pub struct Context {
 // a new calldata. For calldata it'll pass a heap id (or a fat pointer, check this)
 
 impl Context {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         program_code: Vec<U256>,
         gas_stipend: u32,

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -47,7 +47,7 @@ impl Context {
         heap_id: u32,
         aux_heap_id: u32,
         calldata_heap_id: u32,
-        exception_handler: u64
+        exception_handler: u64,
     ) -> Self {
         Self {
             frame: CallFrame::new_far_call_frame(
@@ -57,7 +57,7 @@ impl Context {
                 heap_id,
                 aux_heap_id,
                 calldata_heap_id,
-                exception_handler
+                exception_handler,
             ),
             near_call_frames: vec![],
             contract_address,
@@ -76,7 +76,7 @@ impl CallFrame {
         heap_id: u32,
         aux_heap_id: u32,
         calldata_heap_id: u32,
-        exception_handler: u64
+        exception_handler: u64,
     ) -> Self {
         Self {
             stack: Stack::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,25 +207,37 @@ pub fn run(
                 // This is only to keep the context for tests
                 Variant::Ret(ret_variant) => match ret_variant {
                     RetOpcode::Ok => {
-                        let should_break = ok(&mut vm, &opcode)?;
-                        if should_break {
-                            break;
+                        let should_break = ok(&mut vm, &opcode);
+                        if should_break.is_err() {
+                            Err(should_break.unwrap_err())
+                        } else {
+                            if should_break.unwrap() {
+                                break;
+                            }
+                            Ok(())
                         }
-                        Ok(())
                     }
                     RetOpcode::Revert => {
-                        let should_break = revert(&mut vm, &opcode)?;
-                        if should_break {
-                            return Ok((ExecutionOutput::Revert(vec![]), vm));
+                        let should_break = revert(&mut vm, &opcode);
+                        if should_break.is_err() {
+                            Err(should_break.unwrap_err())
+                        } else {
+                            if should_break.unwrap() {
+                                return Ok((ExecutionOutput::Revert(vec![]), vm));
+                            }
+                            Ok(())
                         }
-                        Ok(())
                     }
                     RetOpcode::Panic => {
-                        let should_break = panic(&mut vm, &opcode)?;
-                        if should_break {
-                            return Ok((ExecutionOutput::Panic, vm));
+                        let should_break = panic(&mut vm, &opcode);
+                        if should_break.is_err() {
+                            Err(should_break.unwrap_err())
+                        } else {
+                            if should_break.unwrap() {
+                                return Ok((ExecutionOutput::Panic, vm));
+                            }
+                            Ok(())
                         }
-                        Ok(())
                     }
                 },
                 Variant::UMA(uma_variant) => match uma_variant {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,39 +206,33 @@ pub fn run(
                 // hooked up.
                 // This is only to keep the context for tests
                 Variant::Ret(ret_variant) => match ret_variant {
-                    RetOpcode::Ok => {
-                        let should_break = ok(&mut vm, &opcode);
-                        if should_break.is_err() {
-                            Err(should_break.unwrap_err())
-                        } else {
-                            if should_break.unwrap() {
+                    RetOpcode::Ok => match ok(&mut vm, &opcode) {
+                        Ok(should_break) => {
+                            if should_break {
                                 break;
                             }
                             Ok(())
                         }
-                    }
-                    RetOpcode::Revert => {
-                        let should_break = revert(&mut vm, &opcode);
-                        if should_break.is_err() {
-                            Err(should_break.unwrap_err())
-                        } else {
-                            if should_break.unwrap() {
+                        Err(e) => Err(e),
+                    },
+                    RetOpcode::Revert => match revert(&mut vm, &opcode) {
+                        Ok(should_break) => {
+                            if should_break {
                                 return Ok((ExecutionOutput::Revert(vec![]), vm));
                             }
                             Ok(())
                         }
-                    }
-                    RetOpcode::Panic => {
-                        let should_break = panic(&mut vm, &opcode);
-                        if should_break.is_err() {
-                            Err(should_break.unwrap_err())
-                        } else {
-                            if should_break.unwrap() {
+                        Err(e) => Err(e),
+                    },
+                    RetOpcode::Panic => match panic(&mut vm, &opcode) {
+                        Ok(should_break) => {
+                            if should_break {
                                 return Ok((ExecutionOutput::Panic, vm));
                             }
                             Ok(())
                         }
-                    }
+                        Err(e) => Err(e),
+                    },
                 },
                 Variant::UMA(uma_variant) => match uma_variant {
                     UMAOpcode::HeapRead => heap_read(&mut vm, &opcode),

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -188,7 +188,7 @@ pub fn far_call(
                 new_heap,
                 new_aux_heap,
                 forward_memory.page,
-                exception_handler
+                exception_handler,
             );
 
             if abi.is_system_call {

--- a/src/state.rs
+++ b/src/state.rs
@@ -169,6 +169,7 @@ impl VMState {
             FIRST_HEAP,
             FIRST_AUX_HEAP,
             CALLDATA_HEAP,
+            0
         );
 
         let heaps = Heaps::new(calldata);
@@ -197,6 +198,7 @@ impl VMState {
                 FIRST_HEAP,
                 FIRST_AUX_HEAP,
                 CALLDATA_HEAP,
+                0
             );
         } else {
             for context in self.running_contexts.iter_mut() {
@@ -240,6 +242,7 @@ impl VMState {
         heap_id: u32,
         aux_heap_id: u32,
         calldata_heap_id: u32,
+        exception_handler: u64
     ) {
         if let Some(context) = self.running_contexts.last_mut() {
             context.frame.gas_left -= Saturating(gas_stipend)
@@ -252,6 +255,7 @@ impl VMState {
             heap_id,
             aux_heap_id,
             calldata_heap_id,
+            exception_handler
         );
         self.running_contexts.push(new_context);
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -169,7 +169,7 @@ impl VMState {
             FIRST_HEAP,
             FIRST_AUX_HEAP,
             CALLDATA_HEAP,
-            0
+            0,
         );
 
         let heaps = Heaps::new(calldata);
@@ -198,7 +198,7 @@ impl VMState {
                 FIRST_HEAP,
                 FIRST_AUX_HEAP,
                 CALLDATA_HEAP,
-                0
+                0,
             );
         } else {
             for context in self.running_contexts.iter_mut() {
@@ -242,7 +242,7 @@ impl VMState {
         heap_id: u32,
         aux_heap_id: u32,
         calldata_heap_id: u32,
-        exception_handler: u64
+        exception_handler: u64,
     ) {
         if let Some(context) = self.running_contexts.last_mut() {
             context.frame.gas_left -= Saturating(gas_stipend)
@@ -255,7 +255,7 @@ impl VMState {
             heap_id,
             aux_heap_id,
             calldata_heap_id,
-            exception_handler
+            exception_handler,
         );
         self.running_contexts.push(new_context);
     }


### PR DESCRIPTION
This PR fixes the tests on return.sol

For that I added some logic regarding far call reverts, specifically when an opcode inside a far call throws an error, however it is just the necessary stuff to make this tests pass, its not complete, and there could even be some unnecessary things.