### PR TITLE
Make registers private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ pub fn run(
         }
         vm.current_frame_mut()?.pc = opcode_pc_set(&opcode, vm.current_frame()?.pc);
     }
-    let fat_pointer_src0 = FatPointer::decode(vm.registers[0].value);
+    let fat_pointer_src0 = FatPointer::decode(vm.get_register(1).value);
     let range = fat_pointer_src0.start..fat_pointer_src0.start + fat_pointer_src0.len;
     let mut result: Vec<u8> = vec![0; range.len()];
     let end: u32 = (range.end).min(

--- a/src/state.rs
+++ b/src/state.rs
@@ -128,7 +128,7 @@ impl VMStateBuilder {
 pub struct VMState {
     // The first register, r0, is actually always zero and not really used.
     // Writing to it does nothing.
-    pub registers: [TaggedValue; 15],
+    registers: [TaggedValue; 15],
     /// Overflow or less than flag
     pub flag_lt_of: bool, // We only use the first three bits for the flags here: LT, GT, EQ.
     /// Greater Than flag


### PR DESCRIPTION
This PR makes the registers from the vm state private in order to only access them through the get/set functions