### PR TITLE
Fix Deployer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ submodules:
 
 deps: submodules
 	cargo install compiler-llvm-builder
-	cd era-compiler-tester && zksync-llvm clone && zksync-llvm build
+	cd era-compiler-tester && \
+	if [ ! -d "llvm" ]; then \
+		zksync-llvm clone && zksync-llvm build; \
+	else \
+		zksync-llvm build; \
+	fi
 
-test:
+test: deps
 	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path  tests/solidity/simple/yul_instructions/ --target EraVM --mode='Y+M3B3 0.8.26'

--- a/src/address_operands.rs
+++ b/src/address_operands.rs
@@ -72,7 +72,7 @@ pub fn address_operands_read(
                     let res = vm
                         .current_context()?
                         .stack
-                        .get_absolute(src0.value.as_usize(),sp)?;
+                        .get_absolute(src0.value.as_usize(), sp)?;
 
                     (res, src1)
                 }
@@ -176,26 +176,31 @@ fn address_operands(
                 ImmMemHandlerFlags::UseStackWithPushPop => {
                     // stack+=[src0 + offset] + src1
                     let src0 = reg_and_imm_write(vm, OutputOperandPosition::First, opcode);
-                    vm.current_frame_mut()?
-                        .sp += src0.value.low_u64() + 1;
+                    vm.current_frame_mut()?.sp += src0.value.low_u64() + 1;
                     let sp = vm.current_frame()?.sp;
-                    vm.current_context_mut()?.stack.store_with_offset(1, res.0,sp)?;
+                    vm.current_context_mut()?
+                        .stack
+                        .store_with_offset(1, res.0, sp)?;
                 }
                 ImmMemHandlerFlags::UseStackWithOffset => {
                     // stack[src0 + offset] + src1
                     let src0 = reg_and_imm_write(vm, OutputOperandPosition::First, opcode);
                     let sp = vm.current_frame()?.sp;
-                    vm.current_context_mut()?
-                        .stack
-                        .store_with_offset(src0.value.as_usize(), res.0,sp)?;
+                    vm.current_context_mut()?.stack.store_with_offset(
+                        src0.value.as_usize(),
+                        res.0,
+                        sp,
+                    )?;
                 }
                 ImmMemHandlerFlags::UseAbsoluteOnStack => {
                     // stack=[src0 + offset] + src1
                     let src0 = reg_and_imm_write(vm, OutputOperandPosition::First, opcode);
                     let sp = vm.current_frame()?.sp;
-                    vm.current_context_mut()?
-                        .stack
-                        .store_absolute(src0.value.as_usize(), res.0,sp)?;
+                    vm.current_context_mut()?.stack.store_absolute(
+                        src0.value.as_usize(),
+                        res.0,
+                        sp,
+                    )?;
                 }
                 ImmMemHandlerFlags::UseImm16Only => {
                     return Err(OperandError::InvalidDestImm16Only(opcode.variant).into());

--- a/src/address_operands.rs
+++ b/src/address_operands.rs
@@ -46,32 +46,35 @@ pub fn address_operands_read(
                 ImmMemHandlerFlags::UseStackWithPushPop => {
                     // stack-=[src0 + offset] + src1
                     let (src0, src1) = reg_and_imm_read(vm, opcode);
-                    let res = *vm
-                        .current_frame()?
+                    let sp = vm.current_frame()?.sp;
+                    let res = vm
+                        .current_context()?
                         .stack
-                        .get_with_offset(src0.value.as_usize())?;
-                    vm.current_frame_mut()?.stack.pop(src0.value)?;
+                        .get_with_offset(src0.value.as_usize(), sp)?;
+                    vm.current_frame_mut()?.sp -= src0.value.low_u64();
                     (res, src1)
                 }
                 ImmMemHandlerFlags::UseStackWithOffset => {
                     // stack[src0 + offset] + src1
                     let (src0, src1) = reg_and_imm_read(vm, opcode);
+                    let sp = vm.current_frame()?.sp;
                     let res = vm
-                        .current_frame()?
+                        .current_context()?
                         .stack
-                        .get_with_offset(src0.value.as_usize())?;
+                        .get_with_offset(src0.value.as_usize(), sp)?;
 
-                    (*res, src1)
+                    (res, src1)
                 }
                 ImmMemHandlerFlags::UseAbsoluteOnStack => {
                     // stack=[src0 + offset] + src1
                     let (src0, src1) = reg_and_imm_read(vm, opcode);
+                    let sp = vm.current_frame()?.sp;
                     let res = vm
-                        .current_frame()?
+                        .current_context()?
                         .stack
-                        .get_absolute(src0.value.as_usize())?;
+                        .get_absolute(src0.value.as_usize(),sp)?;
 
-                    (*res, src1)
+                    (res, src1)
                 }
                 ImmMemHandlerFlags::UseImm16Only => only_imm16_read(vm, opcode),
                 ImmMemHandlerFlags::UseCodePage => {
@@ -174,23 +177,25 @@ fn address_operands(
                     // stack+=[src0 + offset] + src1
                     let src0 = reg_and_imm_write(vm, OutputOperandPosition::First, opcode);
                     vm.current_frame_mut()?
-                        .stack
-                        .fill_with_zeros(src0.value + 1);
-                    vm.current_frame_mut()?.stack.store_with_offset(1, res.0)?;
+                        .sp += src0.value.low_u64() + 1;
+                    let sp = vm.current_frame()?.sp;
+                    vm.current_context_mut()?.stack.store_with_offset(1, res.0,sp)?;
                 }
                 ImmMemHandlerFlags::UseStackWithOffset => {
                     // stack[src0 + offset] + src1
                     let src0 = reg_and_imm_write(vm, OutputOperandPosition::First, opcode);
-                    vm.current_frame_mut()?
+                    let sp = vm.current_frame()?.sp;
+                    vm.current_context_mut()?
                         .stack
-                        .store_with_offset(src0.value.as_usize(), res.0)?;
+                        .store_with_offset(src0.value.as_usize(), res.0,sp)?;
                 }
                 ImmMemHandlerFlags::UseAbsoluteOnStack => {
                     // stack=[src0 + offset] + src1
                     let src0 = reg_and_imm_write(vm, OutputOperandPosition::First, opcode);
-                    vm.current_frame_mut()?
+                    let sp = vm.current_frame()?.sp;
+                    vm.current_context_mut()?
                         .stack
-                        .store_absolute(src0.value.as_usize(), res.0)?;
+                        .store_absolute(src0.value.as_usize(), res.0,sp)?;
                 }
                 ImmMemHandlerFlags::UseImm16Only => {
                     return Err(OperandError::InvalidDestImm16Only(opcode.variant).into());

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -6,8 +6,6 @@ use crate::{state::Stack, store::InMemory};
 
 #[derive(Debug, Clone)]
 pub struct CallFrame {
-    // Max length for this is 1 << 16. Might want to enforce that at some point
-    pub stack: Stack,
     pub heap_id: u32,
     pub aux_heap_id: u32,
     pub calldata_heap_id: u32,
@@ -19,6 +17,7 @@ pub struct CallFrame {
     pub gas_left: Saturating<u32>,
     pub exception_handler: u64,
     pub contract_address: H160,
+    pub sp: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -33,6 +32,8 @@ pub struct Context {
     pub code_address: Address,
     /// Stands for the amount of wei sent in a transaction
     pub context_u128: u128,
+    // Max length for this is 1 << 16. Might want to enforce that at some point
+    pub stack: Stack,
 }
 
 // When someone far calls, the new frame will allocate both a new heap and a new aux heap, but not
@@ -66,6 +67,7 @@ impl Context {
             caller,
             code_address: contract_address,
             context_u128,
+            stack: Stack::new(),
         }
     }
 }
@@ -81,7 +83,6 @@ impl CallFrame {
         exception_handler: u64,
     ) -> Self {
         Self {
-            stack: Stack::new(),
             heap_id,
             aux_heap_id,
             calldata_heap_id,
@@ -91,12 +92,13 @@ impl CallFrame {
             transient_storage: Box::new(InMemory::new_empty()),
             exception_handler,
             contract_address,
+            sp: 0,
         }
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn new_near_call_frame(
-        stack: Stack,
+        sp: u64,
         heap_id: u32,
         aux_heap_id: u32,
         calldata_heap_id: u32,
@@ -109,7 +111,6 @@ impl CallFrame {
     ) -> Self {
         let transient_storage = transient_storage.clone();
         Self {
-            stack,
             heap_id,
             aux_heap_id,
             code_page,
@@ -119,6 +120,7 @@ impl CallFrame {
             transient_storage,
             contract_address,
             exception_handler,
+            sp
         }
     }
 }

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -120,7 +120,7 @@ impl CallFrame {
             transient_storage,
             contract_address,
             exception_handler,
-            sp
+            sp,
         }
     }
 }

--- a/src/op_handlers/context.rs
+++ b/src/op_handlers/context.rs
@@ -61,7 +61,7 @@ pub fn ergs_left(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
 }
 
 pub fn sp(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
-    let sp = vm.current_frame()?.stack.sp();
+    let sp = vm.current_frame()?.sp;
     address_operands_store(vm, opcode, TaggedValue::new_raw_integer(U256::from(sp)))
 }
 

--- a/src/op_handlers/near_call.rs
+++ b/src/op_handlers/near_call.rs
@@ -22,14 +22,14 @@ pub fn near_call(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let current_frame = vm.current_frame_mut()?;
 
     current_frame.pc += 1; // The +1 used later will actually increase the pc of the new frame
-    let new_stack = current_frame.stack.clone();
+    let new_sp = current_frame.sp;
     let new_code_page = current_frame.code_page.clone();
     let transient_storage = current_frame.transient_storage.clone();
     let running_contract_address = current_frame.contract_address;
 
     // Create new frame
     let new_frame = CallFrame::new_near_call_frame(
-        new_stack,
+        new_sp,
         vm.current_frame()?.heap_id,
         vm.current_frame()?.aux_heap_id,
         vm.current_frame()?.calldata_heap_id,

--- a/src/op_handlers/ok.rs
+++ b/src/op_handlers/ok.rs
@@ -14,7 +14,7 @@ pub fn ok(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
         if !vm.current_context()?.near_call_frames.is_empty() {
             // Near call
             let previous_frame = vm.pop_frame()?;
-            vm.current_frame_mut()?.stack = previous_frame.stack;
+            //vm.current_frame_mut()?.stack = previous_frame.stack;
             if opcode.alters_vm_flags {
                 // Marks if it has .to_label
                 let to_label = opcode.imm0;

--- a/src/op_handlers/ok.rs
+++ b/src/op_handlers/ok.rs
@@ -14,7 +14,6 @@ pub fn ok(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
         if !vm.current_context()?.near_call_frames.is_empty() {
             // Near call
             let previous_frame = vm.pop_frame()?;
-            //vm.current_frame_mut()?.stack = previous_frame.stack;
             if opcode.alters_vm_flags {
                 // Marks if it has .to_label
                 let to_label = opcode.imm0;

--- a/src/op_handlers/panic.rs
+++ b/src/op_handlers/panic.rs
@@ -8,7 +8,6 @@ pub fn panic(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
         if !vm.current_context()?.near_call_frames.is_empty() {
             // Near call
             let previous_frame = vm.pop_frame()?;
-            vm.current_frame_mut()?.stack = previous_frame.stack;
             if opcode.alters_vm_flags {
                 // Marks if it has .to_label
                 let to_label = opcode.imm0;

--- a/src/op_handlers/revert.rs
+++ b/src/op_handlers/revert.rs
@@ -17,7 +17,6 @@ pub fn revert(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
         if !vm.current_context()?.near_call_frames.is_empty() {
             // Near call
             let previous_frame = vm.pop_frame()?;
-            vm.current_frame_mut()?.stack = previous_frame.stack;
             if opcode.alters_vm_flags {
                 // Marks if it has .to_label
                 let to_label = opcode.imm0;
@@ -47,7 +46,6 @@ fn revert_near_call(vm: &mut VMState) -> Result<(), EraVmError> {
     let previous_frame = vm.pop_frame()?;
 
     let current_frame = vm.current_frame_mut()?;
-    current_frame.stack = previous_frame.stack;
     current_frame.heap_id = previous_frame.heap_id;
     current_frame.aux_heap_id = previous_frame.aux_heap_id;
     current_frame.pc = previous_frame.exception_handler - 1; // To account for the +1 later

--- a/src/state.rs
+++ b/src/state.rs
@@ -446,7 +446,12 @@ impl Stack {
         Ok(())
     }
 
-    pub fn store_absolute(&mut self, index: usize, value: TaggedValue, sp: u64) -> Result<(), StackError> {
+    pub fn store_absolute(
+        &mut self,
+        index: usize,
+        value: TaggedValue,
+        sp: u64,
+    ) -> Result<(), StackError> {
         if index >= sp as usize {
             return Err(StackError::StoreOutOfBounds);
         }


### PR DESCRIPTION
This PR fixes tests without `--disable-deployer` flag.

In order to do it, the stack was moved to the context, and the callframe now has the stack pointer.