### PR TITLE
Fix array tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ deps: submodules
 	fi
 
 test: deps
-	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path  tests/solidity/simple/ --target EraVM
+	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path  tests/solidity/simple/ --mode "Y+M3B3 0.8.26" --target EraVM

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -1,3 +1,5 @@
+use u256::U256;
+
 use crate::address_operands::address_operands_read;
 use crate::eravm_error::{EraVmError, HeapError, OperandError};
 use crate::value::{FatPointer, TaggedValue};
@@ -10,7 +12,7 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmEr
     }
     let pointer = FatPointer::decode(src0.value);
 
-    if pointer.offset < pointer.len {
+    let value = if pointer.offset < pointer.len {
         let heap = vm
             .heaps
             .get_mut(pointer.page)
@@ -19,21 +21,24 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmEr
         let gas_cost = heap.expand_memory(pointer.start + pointer.offset + 32);
         let value = heap.read_from_pointer(&pointer);
         vm.current_frame_mut()?.gas_left -= gas_cost;
+        value
+    } else {
+        U256::zero()
+    };
 
-        vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));
+    vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));
 
-        if opcode.alters_vm_flags {
-            // This flag is set if .inc is present
-            let new_pointer = FatPointer {
-                offset: pointer.offset + 32,
-                ..pointer
-            };
-
-            vm.set_register(
-                opcode.dst1_index,
-                TaggedValue::new_pointer(new_pointer.encode()),
-            );
+    if opcode.alters_vm_flags {
+        // This flag is set if .inc is present
+        let new_pointer = FatPointer {
+            offset: pointer.offset + 32,
+            ..pointer
         };
-    }
+
+        vm.set_register(
+            opcode.dst1_index,
+            TaggedValue::new_pointer(new_pointer.encode()),
+        );
+    };
     Ok(())
 }


### PR DESCRIPTION
This PR fixes tests under `tests/solidity/simple/array`
It also fixes `tests/solidity/simple/algorithm` 

There was an error on FatPointerRead, where if the pointer offset was equal or higher than the height, nothing was done, and the value of the destination was not changed, it is now changed to 0.