### PR TITLE
Optimize CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     branches: [main]
   pull_request:
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -39,7 +38,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -56,53 +54,52 @@ jobs:
     name: Build VM with Compiler Tester + Run Compiler Tester
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout vm sources
-          uses: actions/checkout@v4
-          with:
-            path: ${{ github.workspace }}/era_vm
+      - name: Checkout vm sources
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}/era_vm
 
+      - name: LLVM Dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: llvm clang clang-tools build-essential lld ninja-build
+          version: 1.0
 
-        - name: LLVM Dependencies
-          uses: awalsh128/cache-apt-pkgs-action@latest
-          with:
-            packages: llvm clang clang-tools build-essential lld ninja-build
-            version: 1.0
+      - uses: dtolnay/rust-toolchain@1.78.0
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: clippy
 
-        - uses: dtolnay/rust-toolchain@1.78.0
-          with:
-            toolchain: ${{ env.RUST_VERSION }}
-            components: clippy
+      - uses: Swatinem/rust-cache@v2
 
-        - uses: Swatinem/rust-cache@v2
+      - name: Fetch zksync-llvm
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: build-binaries.yml
+          repo: matter-labs/era-compiler-llvm
+          if_not_artifact_found: fail
+          path: ${{ github.workspace }}/zksync-llvm
+          workflow_conclusion: success
+          name: llvm-bins-Linux-X64
+          search_artifacts: true
 
-        - name: Fetch zksync-llvm
-          uses: dawidd6/action-download-artifact@v6
-          with:
-            github_token: ${{secrets.GITHUB_TOKEN}}
-            workflow: build-binaries.yml
-            repo: matter-labs/era-compiler-llvm
-            if_not_artifact_found: fail
-            path: ${{ github.workspace }}/zksync-llvm
-            workflow_conclusion: success
-            name: llvm-bins-Linux-X64
-            search_artifacts: true
+      - name: Download zksolc compiler
+        run: curl -L https://github.com/matter-labs/zksolc-bin/releases/download/v1.5.1/zksolc-linux-amd64-musl-v1.5.1 --output zksolc && chmod +x zksolc && sudo mv zksolc /usr/bin/zksolc
 
-        - name: Download zksolc compiler
-          run: curl -L https://github.com/matter-labs/zksolc-bin/releases/download/v1.5.1/zksolc-linux-amd64-musl-v1.5.1 --output zksolc && chmod +x zksolc && sudo mv zksolc /usr/bin/zksolc
+      - name: Download solc compiler
+        run: curl -L https://github.com/ethereum/solidity/releases/download/v0.8.25/solc-static-linux --output solc && chmod +x solc && sudo mv solc /usr/bin/solc
 
-        - name: Download solc compiler
-          run: curl -L https://github.com/ethereum/solidity/releases/download/v0.8.25/solc-static-linux --output solc && chmod +x solc && sudo mv solc /usr/bin/solc
+      - name: Build compiler tester with Lambdaclass VM
+        working-directory: ${{ github.workspace }}/zksync-llvm
+        run: |
+          rm -rfv llvm
+          tar -xvf Linux-X64-target-final.tar.gz
 
-        - name: Build compiler tester with Lambdaclass VM
-          working-directory: ${{ github.workspace }}/zksync-llvm
-          run: |
-            rm -rfv llvm
-            tar -xvf Linux-X64-target-final.tar.gz
+      - name: Setup compiler-tester submodule
+        working-directory: ${{ github.workspace }}/era_vm
+        run: make submodules
 
-        - name: Setup compiler-tester submodule
-          working-directory: ${{ github.workspace }}/era_vm
-          run: make submodules
-
-        - name: Run compiler-tester tests
-          working-directory: ${{ github.workspace }}/era_vm
-          run: make test LLVM_PATH=$(pwd)/../zksync-llvm/target-llvm/target-final
+      - name: Run compiler-tester tests
+        working-directory: ${{ github.workspace }}/era_vm
+        run: make ci-test LLVM_PATH=$(pwd)/../zksync-llvm/target-llvm/target-final

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ program_artifacts
 /tests/test_storage
 .test_db*
 **/.DS_Store
+era-compiler-tester

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,14 @@ submodules:
 
 deps: submodules
 	cargo install compiler-llvm-builder
-	cd era-compiler-tester && \
-	if [ ! -d "llvm" ]; then \
+	if [ ! -d $(LLVM_PATH) ]; then \
+	    cd era-compiler-tester && \
 		zksync-llvm clone && zksync-llvm build; \
-	else \
-		zksync-llvm build; \
 	fi
 
-test: deps
+# CI test uses LLVM from the era-compiler-llvm repository, doesn't need to build it
+ci-test:
 	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path  tests/solidity/simple/yul_instructions/ --target EraVM --mode='Y+M3B3 0.8.26'
+
+# Local test uses LLVM from era-compiler-tester submodule, needs to build it
+test: deps ci-test

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,10 @@ deps: submodules
 		zksync-llvm clone && zksync-llvm build; \
 	fi
 
+# Local test uses LLVM from era-compiler-tester submodule, needs to build it
+test: deps
+	cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path tests/solidity/simple/yul_instructions/ --target EraVM --mode='Y+M3B3 0.8.26'
+
 # CI test uses LLVM from the era-compiler-llvm repository, doesn't need to build it
 ci-test:
-	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path  tests/solidity/simple/yul_instructions/ --target EraVM --mode='Y+M3B3 0.8.26'
-
-# Local test uses LLVM from era-compiler-tester submodule, needs to build it
-test: deps ci-test
+	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && $(MAKE) test


### PR DESCRIPTION
- Current CI runs `make test` which itself does `make deps` this builds a llvm that the CI won't make use of.
- Removing the `deps` dependency from `test` is not possible (makes local tests fail)

Solution is splitting them into two separate `make` commands:
```Makefile
deps: submodules
	cargo install compiler-llvm-builder
	if [ ! -d $(LLVM_PATH) ]; then \
	    cd era-compiler-tester && \
		zksync-llvm clone && zksync-llvm build; \
	fi

# CI test uses LLVM from the era-compiler-llvm repository, doesn't need to build it
ci-test:
	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path  tests/solidity/simple/yul_instructions/ --target EraVM --mode='Y+M3B3 0.8.26'

# Local test uses LLVM from era-compiler-tester submodule, needs to build it
test: deps ci-test
```

This PR also adds `era-compiler-tester` submodule path to `.gitignore`.