### PR TITLE
Fix revert not returning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ deps: submodules
 	fi
 
 test: deps
-	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path  tests/solidity/simple/ --target EraVM
+	export LLVM_SYS_170_PREFIX=$(LLVM_PATH) && cd era-compiler-tester && cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path  tests/solidity/simple/ --target EraVM --mode "Y+M3B3 0.8.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ pub fn run(
     Ok((ExecutionOutput::Ok(result), vm))
 }
 
-// Set the next PC according to th enext opcode
+// Set the next PC according to the next opcode
 fn opcode_pc_set(opcode: &Opcode, current_pc: u64) -> u64 {
     match opcode.variant {
         Variant::FarCall(_) => 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ fn opcode_pc_set(opcode: &Opcode, current_pc: u64) -> u64 {
     }
 }
 
-fn retrieve_result(vm: &mut VMState,) -> Result<Vec<u8>,EraVmError> {
+fn retrieve_result(vm: &mut VMState) -> Result<Vec<u8>, EraVmError> {
     let fat_pointer_src0 = FatPointer::decode(vm.get_register(1).value);
     let range = fat_pointer_src0.start..fat_pointer_src0.start + fat_pointer_src0.len;
     let mut result: Vec<u8> = vec![0; range.len()];

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -1,5 +1,4 @@
 use u256::{H160, U256};
-use zk_evm_abstractions::vm;
 use zkevm_opcode_defs::{
     ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW, FarCallOpcode,
 };

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -1,4 +1,5 @@
 use u256::{H160, U256};
+use zk_evm_abstractions::vm;
 use zkevm_opcode_defs::{
     ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW, FarCallOpcode,
 };
@@ -287,4 +288,14 @@ pub(crate) fn get_far_call_arguments(abi: U256) -> FarCallABI {
         is_constructor_call: constructor_call_byte != 0,
         is_system_call: system_call_byte != 0,
     }
+}
+
+pub fn perform_return(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
+    let register = vm.get_register(opcode.src0_index);
+    let result = get_forward_memory_pointer(register.value, vm, register.is_pointer)?;
+    vm.set_register(
+        opcode.src0_index,
+        TaggedValue::new_pointer(FatPointer::encode(&result)),
+    );
+    Ok(())
 }

--- a/src/op_handlers/ok.rs
+++ b/src/op_handlers/ok.rs
@@ -6,24 +6,21 @@ pub fn ok(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
     vm.flag_eq = false;
     vm.flag_lt_of = false;
     vm.flag_gt = false;
-    if vm.running_contexts.len() > 1 || !vm.current_context()?.near_call_frames.is_empty() {
-        if !vm.current_context()?.near_call_frames.is_empty() {
-            // Near call
-            let previous_frame = vm.pop_frame()?;
-            if opcode.alters_vm_flags {
-                // Marks if it has .to_label
-                let to_label = opcode.imm0;
-                vm.current_frame_mut()?.pc = (to_label - 1) as u64; // To account for the +1 later
-            } else {
-                vm.current_frame_mut()?.pc -= 1; // To account for the +1 later
-            }
-            vm.current_frame_mut()?.gas_left += previous_frame.gas_left;
+    if vm.in_near_call()? {
+        let previous_frame = vm.pop_frame()?;
+        if opcode.alters_vm_flags {
+            // Marks if it has .to_label
+            let to_label = opcode.imm0;
+            vm.current_frame_mut()?.pc = (to_label - 1) as u64; // To account for the +1 later
         } else {
-            // Far call
-            perform_return(vm, opcode)?;
-            vm.register_context_u128 = 0_u128;
-            vm.pop_frame()?;
+            vm.current_frame_mut()?.pc -= 1; // To account for the +1 later
         }
+        vm.current_frame_mut()?.gas_left += previous_frame.gas_left;
+        Ok(false)
+    } else if vm.in_far_call() {
+        perform_return(vm, opcode)?;
+        vm.register_context_u128 = 0_u128;
+        vm.pop_frame()?;
         Ok(false)
     } else {
         perform_return(vm, opcode)?;

--- a/src/op_handlers/ok.rs
+++ b/src/op_handlers/ok.rs
@@ -6,6 +6,8 @@ use crate::{
     Opcode,
 };
 
+use super::far_call::perform_return;
+
 pub fn ok(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
     vm.flag_eq = false;
     vm.flag_lt_of = false;
@@ -24,23 +26,13 @@ pub fn ok(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
             vm.current_frame_mut()?.gas_left += previous_frame.gas_left;
         } else {
             // Far call
-            let register = vm.get_register(opcode.src0_index);
-            let result = get_forward_memory_pointer(register.value, vm, register.is_pointer)?;
-            vm.set_register(
-                opcode.src0_index,
-                TaggedValue::new_pointer(FatPointer::encode(&result)),
-            );
+            perform_return(vm, opcode)?;
             vm.register_context_u128 = 0_u128;
             vm.pop_frame()?;
         }
         Ok(false)
     } else {
-        let register = vm.get_register(opcode.src0_index);
-        let result = get_forward_memory_pointer(register.value, vm, register.is_pointer)?;
-        vm.set_register(
-            opcode.src0_index,
-            TaggedValue::new_pointer(FatPointer::encode(&result)),
-        );
+        perform_return(vm, opcode)?;
         Ok(true)
     }
 }

--- a/src/op_handlers/ok.rs
+++ b/src/op_handlers/ok.rs
@@ -1,10 +1,4 @@
-use crate::{
-    eravm_error::EraVmError,
-    op_handlers::far_call::get_forward_memory_pointer,
-    state::VMState,
-    value::{FatPointer, TaggedValue},
-    Opcode,
-};
+use crate::{eravm_error::EraVmError, state::VMState, Opcode};
 
 use super::far_call::perform_return;
 

--- a/src/op_handlers/panic.rs
+++ b/src/op_handlers/panic.rs
@@ -4,22 +4,19 @@ pub fn panic(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
     vm.flag_eq = false;
     vm.flag_lt_of = true;
     vm.flag_gt = false;
-    if vm.running_contexts.len() > 1 || !vm.current_context()?.near_call_frames.is_empty() {
-        if !vm.current_context()?.near_call_frames.is_empty() {
-            // Near call
-            let previous_frame = vm.pop_frame()?;
-            if opcode.alters_vm_flags {
-                // Marks if it has .to_label
-                let to_label = opcode.imm0;
-                vm.current_frame_mut()?.pc = (to_label - 1) as u64; // To account for the +1 later
-            } else {
-                vm.current_frame_mut()?.pc = previous_frame.exception_handler - 1;
-                // To account for the +1 later
-            }
+    if vm.in_near_call()? {
+        let previous_frame = vm.pop_frame()?;
+        if opcode.alters_vm_flags {
+            // Marks if it has .to_label
+            let to_label = opcode.imm0;
+            vm.current_frame_mut()?.pc = (to_label - 1) as u64; // To account for the +1 later
         } else {
-            // Far call
-            vm.pop_frame()?;
+            vm.current_frame_mut()?.pc = previous_frame.exception_handler - 1;
+            // To account for the +1 later
         }
+        Ok(false)
+    } else if vm.in_far_call() {
+        vm.pop_frame()?;
         Ok(false)
     } else {
         Ok(true)

--- a/src/op_handlers/revert.rs
+++ b/src/op_handlers/revert.rs
@@ -7,7 +7,7 @@ use crate::{
     Opcode,
 };
 
-use super::far_call::get_forward_memory_pointer;
+use super::far_call::{get_forward_memory_pointer, perform_return};
 
 pub fn revert(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
     vm.flag_eq = false;
@@ -38,12 +38,7 @@ pub fn revert(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
         }
         Ok(false)
     } else {
-        let register = vm.get_register(opcode.src0_index);
-        let result = get_forward_memory_pointer(register.value, vm, register.is_pointer)?;
-        vm.set_register(
-            opcode.src0_index,
-            TaggedValue::new_pointer(FatPointer::encode(&result)),
-        );
+        perform_return(vm, opcode)?;
         Ok(true)
     }
 }

--- a/src/op_handlers/revert.rs
+++ b/src/op_handlers/revert.rs
@@ -67,8 +67,7 @@ pub fn revert_out_of_gas(vm: &mut VMState) -> Result<(), EraVmError> {
     vm.flag_eq = false;
     vm.flag_lt_of = false;
     vm.flag_gt = false;
-    if !vm.current_context()?.near_call_frames.is_empty() {
-        // Near call
+    if vm.in_near_call()? {
         let previous_frame = vm.pop_frame()?;
         vm.current_frame_mut()?.pc = previous_frame.exception_handler - 1; // To account for the +1 later
         vm.current_frame_mut()?.gas_left += previous_frame.gas_left;
@@ -82,9 +81,9 @@ pub fn handle_error(vm: &mut VMState, err: EraVmError) -> Result<(), EraVmError>
     vm.flag_eq = false;
     vm.flag_lt_of = false;
     vm.flag_gt = false;
-    if !vm.current_context()?.near_call_frames.is_empty() {
+    if vm.in_near_call()? {
         revert_near_call(vm)?;
-    } else if vm.running_contexts.len() > 1 {
+    } else if vm.in_far_call() {
         revert_far_call(vm)?;
     } else {
         // Main context

--- a/src/op_handlers/revert.rs
+++ b/src/op_handlers/revert.rs
@@ -13,29 +13,27 @@ pub fn revert(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
     vm.flag_eq = false;
     vm.flag_lt_of = false;
     vm.flag_gt = false;
-    if vm.running_contexts.len() > 1 || !vm.current_context()?.near_call_frames.is_empty() {
-        if !vm.current_context()?.near_call_frames.is_empty() {
-            // Near call
-            let previous_frame = vm.pop_frame()?;
-            if opcode.alters_vm_flags {
-                // Marks if it has .to_label
-                let to_label = opcode.imm0;
-                vm.current_frame_mut()?.pc = (to_label - 1) as u64;
-            // To account for the +1 later
-            } else {
-                vm.current_frame_mut()?.pc = previous_frame.exception_handler - 1;
-                // To account for the +1 later
-            }
-            vm.current_frame_mut()?.gas_left += previous_frame.gas_left;
+    if vm.in_near_call()? {
+        let previous_frame = vm.pop_frame()?;
+        if opcode.alters_vm_flags {
+            // Marks if it has .to_label
+            let to_label = opcode.imm0;
+            vm.current_frame_mut()?.pc = (to_label - 1) as u64;
+        // To account for the +1 later
         } else {
-            let register = vm.get_register(opcode.src0_index);
-            let result = get_forward_memory_pointer(register.value, vm, register.is_pointer)?;
-            vm.clear_registers();
-            vm.set_register(1, TaggedValue::new_pointer(FatPointer::encode(&result)));
-            vm.flag_lt_of = true;
-            let previous_frame = vm.pop_frame()?;
-            vm.current_frame_mut()?.pc = previous_frame.exception_handler;
+            vm.current_frame_mut()?.pc = previous_frame.exception_handler - 1;
+            // To account for the +1 later
         }
+        vm.current_frame_mut()?.gas_left += previous_frame.gas_left;
+        Ok(false)
+    } else if vm.in_far_call() {
+        let register = vm.get_register(opcode.src0_index);
+        let result = get_forward_memory_pointer(register.value, vm, register.is_pointer)?;
+        vm.clear_registers();
+        vm.set_register(1, TaggedValue::new_pointer(FatPointer::encode(&result)));
+        vm.flag_lt_of = true;
+        let previous_frame = vm.pop_frame()?;
+        vm.current_frame_mut()?.pc = previous_frame.exception_handler;
         Ok(false)
     } else {
         perform_return(vm, opcode)?;

--- a/src/op_handlers/revert.rs
+++ b/src/op_handlers/revert.rs
@@ -38,6 +38,12 @@ pub fn revert(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
         }
         Ok(false)
     } else {
+        let register = vm.get_register(opcode.src0_index);
+        let result = get_forward_memory_pointer(register.value, vm, register.is_pointer)?;
+        vm.set_register(
+            opcode.src0_index,
+            TaggedValue::new_pointer(FatPointer::encode(&result)),
+        );
         Ok(true)
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -382,6 +382,14 @@ impl VMState {
     pub fn gas_left(&self) -> Result<u32, EraVmError> {
         Ok(self.current_frame()?.gas_left.0)
     }
+
+    pub fn in_near_call(&self) -> Result<bool, EraVmError> {
+        Ok(!self.current_context()?.near_call_frames.is_empty())
+    }
+
+    pub fn in_far_call(&self) -> bool {
+        self.running_contexts.len() > 1
+    }
 }
 
 impl Default for Stack {


### PR DESCRIPTION
This PR fixes the following tests:
`tests/solidity/simple/conditional`
`tests/solidity/simple/error`
`tests/solidity/simple/modular`
`tests/solidity/simple/overflow`

Changes output to the following tests:
`tests/solidity/simple/operator`
`tests/solidity/simple/solidity_by_example`
`tests/solidity/simple/yul_semantics`

The revert opcode was not returning any values.