### PR TITLE
Move heap ids, code page and current contract address from `CallFrame` to `Context`

### DIFF
--- a/src/address_operands.rs
+++ b/src/address_operands.rs
@@ -80,7 +80,7 @@ pub fn address_operands_read(
                 ImmMemHandlerFlags::UseCodePage => {
                     let (src0, src1) = reg_and_imm_read(vm, opcode);
 
-                    let res = vm.current_frame()?.code_page[src0.value.as_usize()];
+                    let res = vm.current_context()?.code_page[src0.value.as_usize()];
                     (TaggedValue::new_raw_integer(res), src1)
                 }
             }

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -1,22 +1,16 @@
 use std::num::Saturating;
-use u256::{H160, U256};
+use u256::U256;
 use zkevm_opcode_defs::ethereum_types::Address;
 
 use crate::{state::Stack, store::InMemory};
 
 #[derive(Debug, Clone)]
 pub struct CallFrame {
-    pub heap_id: u32,
-    pub aux_heap_id: u32,
-    pub calldata_heap_id: u32,
-    // Code memory is word addressable even though instructions are 64 bit wide.
-    pub code_page: Vec<U256>,
     pub pc: u64,
     /// Transient storage should be used for temporary storage within a transaction and then discarded.
     pub transient_storage: Box<InMemory>,
     pub gas_left: Saturating<u32>,
     pub exception_handler: u64,
-    pub contract_address: H160,
     pub sp: u64,
 }
 
@@ -34,6 +28,11 @@ pub struct Context {
     pub context_u128: u128,
     // Max length for this is 1 << 16. Might want to enforce that at some point
     pub stack: Stack,
+    pub heap_id: u32,
+    pub aux_heap_id: u32,
+    pub calldata_heap_id: u32,
+    // Code memory is word addressable even though instructions are 64 bit wide.
+    pub code_page: Vec<U256>,
 }
 
 // When someone far calls, the new frame will allocate both a new heap and a new aux heap, but not
@@ -53,45 +52,28 @@ impl Context {
         context_u128: u128,
     ) -> Self {
         Self {
-            frame: CallFrame::new_far_call_frame(
-                program_code,
-                gas_stipend,
-                contract_address,
-                heap_id,
-                aux_heap_id,
-                calldata_heap_id,
-                exception_handler,
-            ),
+            frame: CallFrame::new_far_call_frame(gas_stipend, exception_handler),
             near_call_frames: vec![],
             contract_address,
             caller,
             code_address: contract_address,
             context_u128,
             stack: Stack::new(),
+            heap_id,
+            aux_heap_id,
+            calldata_heap_id,
+            code_page: program_code,
         }
     }
 }
 
 impl CallFrame {
-    pub fn new_far_call_frame(
-        program_code: Vec<U256>,
-        gas_stipend: u32,
-        contract_address: H160,
-        heap_id: u32,
-        aux_heap_id: u32,
-        calldata_heap_id: u32,
-        exception_handler: u64,
-    ) -> Self {
+    pub fn new_far_call_frame(gas_stipend: u32, exception_handler: u64) -> Self {
         Self {
-            heap_id,
-            aux_heap_id,
-            calldata_heap_id,
-            code_page: program_code,
             pc: 0,
             gas_left: Saturating(gas_stipend),
             transient_storage: Box::new(InMemory::new_empty()),
             exception_handler,
-            contract_address,
             sp: 0,
         }
     }
@@ -99,26 +81,16 @@ impl CallFrame {
     #[allow(clippy::too_many_arguments)]
     pub fn new_near_call_frame(
         sp: u64,
-        heap_id: u32,
-        aux_heap_id: u32,
-        calldata_heap_id: u32,
-        code_page: Vec<U256>,
         pc: u64,
         gas_stipend: u32,
-        contract_address: H160,
         transient_storage: Box<InMemory>,
         exception_handler: u64,
     ) -> Self {
         let transient_storage = transient_storage.clone();
         Self {
-            heap_id,
-            aux_heap_id,
-            code_page,
-            calldata_heap_id,
             pc,
             gas_left: Saturating(gas_stipend),
             transient_storage,
-            contract_address,
             exception_handler,
             sp,
         }

--- a/src/op_handlers/aux_heap_read.rs
+++ b/src/op_handlers/aux_heap_read.rs
@@ -19,14 +19,14 @@ pub fn aux_heap_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError
 
     let gas_cost = vm
         .heaps
-        .get_mut(vm.current_frame()?.aux_heap_id)
+        .get_mut(vm.current_context()?.aux_heap_id)
         .ok_or(HeapError::ReadOutOfBounds)?
         .expand_memory(addr + 32);
     vm.current_frame_mut()?.gas_left -= gas_cost;
 
     let value = vm
         .heaps
-        .get(vm.current_frame()?.aux_heap_id)
+        .get(vm.current_context()?.aux_heap_id)
         .ok_or(HeapError::ReadOutOfBounds)?
         .read(addr);
     vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));

--- a/src/op_handlers/aux_heap_write.rs
+++ b/src/op_handlers/aux_heap_write.rs
@@ -19,13 +19,13 @@ pub fn aux_heap_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmErro
 
     let gas_cost = vm
         .heaps
-        .get_mut(vm.current_frame()?.aux_heap_id)
+        .get_mut(vm.current_context()?.aux_heap_id)
         .ok_or(HeapError::ReadOutOfBounds)?
         .expand_memory(addr + 32);
     vm.current_frame_mut()?.gas_left -= gas_cost;
 
     vm.heaps
-        .get_mut(vm.current_frame()?.aux_heap_id)
+        .get_mut(vm.current_context()?.aux_heap_id)
         .ok_or(HeapError::ReadOutOfBounds)?
         .store(addr, src1.value);
 

--- a/src/op_handlers/context.rs
+++ b/src/op_handlers/context.rs
@@ -37,12 +37,12 @@ pub fn meta(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
         (VmMetaParameters {
             heap_size: vm
                 .heaps
-                .get(vm.current_frame()?.heap_id)
+                .get(vm.current_context()?.heap_id)
                 .ok_or(HeapError::ReadOutOfBounds)?
                 .len() as u32,
             aux_heap_size: vm
                 .heaps
-                .get(vm.current_frame()?.aux_heap_id)
+                .get(vm.current_context()?.aux_heap_id)
                 .ok_or(HeapError::ReadOutOfBounds)?
                 .len() as u32,
             this_shard_id: 0,   //

--- a/src/op_handlers/event.rs
+++ b/src/op_handlers/event.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 
 pub fn event(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
-    if vm.current_frame()?.contract_address == H160::from_low_u64_be(ADDRESS_EVENT_WRITER as u64) {
+    if vm.current_context()?.contract_address == H160::from_low_u64_be(ADDRESS_EVENT_WRITER as u64)
+    {
         let key = vm.get_register(opcode.src0_index).value;
         let value = vm.get_register(opcode.src1_index).value;
         let event = Event {

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -72,16 +72,16 @@ pub fn get_forward_memory_pointer(
 
             let ergs_cost = match pointer_kind {
                 PointerSource::NewForHeap => {
-                    pointer.page = vm.current_frame()?.heap_id;
+                    pointer.page = vm.current_context()?.heap_id;
                     vm.heaps
-                        .get_mut(vm.current_frame()?.heap_id)
+                        .get_mut(vm.current_context()?.heap_id)
                         .ok_or(HeapError::StoreOutOfBounds)?
                         .expand_memory(bound)
                 }
                 PointerSource::NewForAuxHeap => {
-                    pointer.page = vm.current_frame()?.aux_heap_id;
+                    pointer.page = vm.current_context()?.aux_heap_id;
                     vm.heaps
-                        .get_mut(vm.current_frame()?.aux_heap_id)
+                        .get_mut(vm.current_context()?.aux_heap_id)
                         .ok_or(HeapError::StoreOutOfBounds)?
                         .expand_memory(pointer.start + pointer.len)
                 }
@@ -182,7 +182,7 @@ pub fn far_call(
                 program_code,
                 ergs_passed,
                 contract_address,
-                vm.current_frame()?.contract_address,
+                vm.current_context()?.contract_address,
                 new_heap,
                 new_aux_heap,
                 forward_memory.page,

--- a/src/op_handlers/heap_read.rs
+++ b/src/op_handlers/heap_read.rs
@@ -19,14 +19,14 @@ pub fn heap_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
 
     let gas_cost = vm
         .heaps
-        .get_mut(vm.current_frame()?.heap_id)
+        .get_mut(vm.current_context()?.heap_id)
         .ok_or(HeapError::StoreOutOfBounds)?
         .expand_memory(addr + 32); // TODO: Handle ergs cost
     vm.current_frame_mut()?.gas_left -= gas_cost;
 
     let value = vm
         .heaps
-        .get(vm.current_frame()?.heap_id)
+        .get(vm.current_context()?.heap_id)
         .ok_or(HeapError::ReadOutOfBounds)?
         .read(addr);
     vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));

--- a/src/op_handlers/heap_write.rs
+++ b/src/op_handlers/heap_write.rs
@@ -19,13 +19,13 @@ pub fn heap_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
 
     let gas_cost = vm
         .heaps
-        .get_mut(vm.current_frame()?.heap_id)
+        .get_mut(vm.current_context()?.heap_id)
         .ok_or(HeapError::StoreOutOfBounds)?
         .expand_memory(addr + 32);
     vm.current_frame_mut()?.gas_left -= gas_cost;
 
     vm.heaps
-        .get_mut(vm.current_frame()?.heap_id)
+        .get_mut(vm.current_context()?.heap_id)
         .ok_or(HeapError::StoreOutOfBounds)?
         .store(addr, src1.value);
 

--- a/src/op_handlers/log.rs
+++ b/src/op_handlers/log.rs
@@ -39,7 +39,7 @@ pub fn transient_storage_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), 
     let address = vm.current_context()?.contract_address;
     let key = StorageKey::new(address, key_for_contract_storage);
     let value = vm.get_register(opcode.src1_index).value;
-    vm.current_frame_mut()?
+    vm.current_context_mut()?
         .transient_storage
         .storage_write(key, value)?;
     Ok(())
@@ -50,7 +50,7 @@ pub fn transient_storage_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), E
     let address = vm.current_context()?.contract_address;
     let key = StorageKey::new(address, key_for_contract_storage);
     let value = vm
-        .current_frame()?
+        .current_context()?
         .transient_storage
         .storage_read(key)?
         .unwrap_or(U256::zero());

--- a/src/op_handlers/log.rs
+++ b/src/op_handlers/log.rs
@@ -14,7 +14,7 @@ pub fn storage_write(
     storage: &mut dyn Storage,
 ) -> Result<(), EraVmError> {
     let key_for_contract_storage = vm.get_register(opcode.src0_index).value;
-    let address = vm.current_frame()?.contract_address;
+    let address = vm.current_context()?.contract_address;
     let key = StorageKey::new(address, key_for_contract_storage);
     let value = vm.get_register(opcode.src1_index).value;
     storage.storage_write(key, value)?;
@@ -27,7 +27,7 @@ pub fn storage_read(
     storage: &mut dyn Storage,
 ) -> Result<(), EraVmError> {
     let key_for_contract_storage = vm.get_register(opcode.src0_index).value;
-    let address = vm.current_frame()?.contract_address;
+    let address = vm.current_context()?.contract_address;
     let key = StorageKey::new(address, key_for_contract_storage);
     let value = storage.storage_read(key)?.unwrap_or(U256::zero());
     vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));
@@ -36,7 +36,7 @@ pub fn storage_read(
 
 pub fn transient_storage_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let key_for_contract_storage = vm.get_register(opcode.src0_index).value;
-    let address = vm.current_frame()?.contract_address;
+    let address = vm.current_context()?.contract_address;
     let key = StorageKey::new(address, key_for_contract_storage);
     let value = vm.get_register(opcode.src1_index).value;
     vm.current_frame_mut()?
@@ -47,7 +47,7 @@ pub fn transient_storage_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), 
 
 pub fn transient_storage_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let key_for_contract_storage = vm.get_register(opcode.src0_index).value;
-    let address = vm.current_frame()?.contract_address;
+    let address = vm.current_context()?.contract_address;
     let key = StorageKey::new(address, key_for_contract_storage);
     let value = vm
         .current_frame()?

--- a/src/op_handlers/log.rs
+++ b/src/op_handlers/log.rs
@@ -39,7 +39,7 @@ pub fn transient_storage_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), 
     let address = vm.current_context()?.contract_address;
     let key = StorageKey::new(address, key_for_contract_storage);
     let value = vm.get_register(opcode.src1_index).value;
-    vm.current_context_mut()?
+    vm.current_frame_mut()?
         .transient_storage
         .storage_write(key, value)?;
     Ok(())
@@ -50,7 +50,7 @@ pub fn transient_storage_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), E
     let address = vm.current_context()?.contract_address;
     let key = StorageKey::new(address, key_for_contract_storage);
     let value = vm
-        .current_context()?
+        .current_frame()?
         .transient_storage
         .storage_read(key)?
         .unwrap_or(U256::zero());

--- a/src/op_handlers/near_call.rs
+++ b/src/op_handlers/near_call.rs
@@ -23,16 +23,10 @@ pub fn near_call(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
 
     current_frame.pc += 1; // The +1 used later will actually increase the pc of the new frame
     let new_sp = current_frame.sp;
-    let transient_storage = current_frame.transient_storage.clone();
 
     // Create new frame
-    let new_frame = CallFrame::new_near_call_frame(
-        new_sp,
-        call_pc,
-        callee_ergs,
-        transient_storage,
-        exception_handler as u64,
-    );
+    let new_frame =
+        CallFrame::new_near_call_frame(new_sp, call_pc, callee_ergs, exception_handler as u64);
 
     vm.push_near_call_frame(new_frame)
 }

--- a/src/op_handlers/near_call.rs
+++ b/src/op_handlers/near_call.rs
@@ -23,10 +23,16 @@ pub fn near_call(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
 
     current_frame.pc += 1; // The +1 used later will actually increase the pc of the new frame
     let new_sp = current_frame.sp;
+    let transient_storage = current_frame.transient_storage.clone();
 
     // Create new frame
-    let new_frame =
-        CallFrame::new_near_call_frame(new_sp, call_pc, callee_ergs, exception_handler as u64);
+    let new_frame = CallFrame::new_near_call_frame(
+        new_sp,
+        call_pc,
+        callee_ergs,
+        transient_storage,
+        exception_handler as u64,
+    );
 
     vm.push_near_call_frame(new_frame)
 }

--- a/src/op_handlers/near_call.rs
+++ b/src/op_handlers/near_call.rs
@@ -6,7 +6,7 @@ use crate::{opcode::Opcode, state::VMState};
 
 pub fn near_call(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let abi_reg = vm.get_register(opcode.src0_index);
-    let callee_address = opcode.imm0;
+    let call_pc = (opcode.imm0 - 1) as u64;
     let exception_handler = opcode.imm1; //TODO: Add exception handler to call frame
 
     let ergs_passed = NearCallABI::new(abi_reg.value).ergs_passed;
@@ -23,20 +23,13 @@ pub fn near_call(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
 
     current_frame.pc += 1; // The +1 used later will actually increase the pc of the new frame
     let new_sp = current_frame.sp;
-    let new_code_page = current_frame.code_page.clone();
     let transient_storage = current_frame.transient_storage.clone();
-    let running_contract_address = current_frame.contract_address;
 
     // Create new frame
     let new_frame = CallFrame::new_near_call_frame(
         new_sp,
-        vm.current_frame()?.heap_id,
-        vm.current_frame()?.aux_heap_id,
-        vm.current_frame()?.calldata_heap_id,
-        new_code_page,
-        callee_address as u64 - 1,
+        call_pc,
         callee_ergs,
-        running_contract_address,
         transient_storage,
         exception_handler as u64,
     );

--- a/src/op_handlers/precompile_call.rs
+++ b/src/op_handlers/precompile_call.rs
@@ -31,10 +31,10 @@ pub fn precompile_call(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmErr
 
     let mut abi = PrecompileCallABI::from_u256(vm.get_register(opcode.src0_index).value);
     if abi.memory_page_to_read == 0 {
-        abi.memory_page_to_read = vm.current_frame()?.heap_id;
+        abi.memory_page_to_read = vm.current_context()?.heap_id;
     }
     if abi.memory_page_to_write == 0 {
-        abi.memory_page_to_write = vm.current_frame()?.heap_id;
+        abi.memory_page_to_write = vm.current_context()?.heap_id;
     }
 
     let query = LogQuery {

--- a/src/op_handlers/revert.rs
+++ b/src/op_handlers/revert.rs
@@ -44,10 +44,7 @@ pub fn revert(vm: &mut VMState, opcode: &Opcode) -> Result<bool, EraVmError> {
 
 fn revert_near_call(vm: &mut VMState) -> Result<(), EraVmError> {
     let previous_frame = vm.pop_frame()?;
-
     let current_frame = vm.current_frame_mut()?;
-    current_frame.heap_id = previous_frame.heap_id;
-    current_frame.aux_heap_id = previous_frame.aux_heap_id;
     current_frame.pc = previous_frame.exception_handler - 1; // To account for the +1 later
     current_frame.gas_left += previous_frame.gas_left;
     Ok(())

--- a/src/state.rs
+++ b/src/state.rs
@@ -208,13 +208,8 @@ impl VMState {
             );
         } else {
             for context in self.running_contexts.iter_mut() {
-                if context.frame.code_page.is_empty() {
-                    context.frame.code_page.clone_from(&program_code);
-                }
-                for frame in context.near_call_frames.iter_mut() {
-                    if frame.code_page.is_empty() {
-                        frame.code_page.clone_from(&program_code);
-                    }
+                if context.code_page.is_empty() {
+                    context.code_page.clone_from(&program_code);
                 }
             }
         }
@@ -355,8 +350,8 @@ impl VMState {
     }
 
     pub fn get_opcode(&self, opcode_table: &[OpcodeVariant]) -> Result<Opcode, EraVmError> {
-        let current_context = self.current_frame()?;
-        let pc = current_context.pc;
+        let current_context = self.current_context()?;
+        let pc = self.current_frame()?.pc;
         let raw_opcode = current_context.code_page[(pc / 4) as usize];
         let raw_opcode_64 = match pc % 4 {
             3 => (raw_opcode & u64::MAX.into()).as_u64(),

--- a/src/tracers/print_tracer.rs
+++ b/src/tracers/print_tracer.rs
@@ -32,13 +32,13 @@ impl Tracer for PrintTracer {
                 if fat_ptr.offset == DEBUG_SLOT {
                     let how_to_print_value = vm
                         .heaps
-                        .get(vm.current_frame()?.heap_id)
+                        .get(vm.current_context()?.heap_id)
                         .ok_or(HeapError::ReadOutOfBounds)?
                         .read(DEBUG_SLOT + 32);
 
                     let value_to_print = vm
                         .heaps
-                        .get(vm.current_frame()?.heap_id)
+                        .get(vm.current_context()?.heap_id)
                         .ok_or(HeapError::ReadOutOfBounds)?
                         .read(DEBUG_SLOT + 64);
 


### PR DESCRIPTION
### Description

Currently, there are some attributes that we store under `CallFrame` struct which should be moved to `Context` struct, since they are not modified, but copied on a near call.

### Changes

* Moved `heap_id`, `aux_heap_id`, `calldata_heap_id`, `code_page` from `CallFrame` to `Context`.
* Deleted `contract_address` from `CallFrame`
* Modified `new_far_call_frame` and `new_near_call_frame` to cope with attribute changes.

Closes #92