### PR TITLE
Fix `internal_function_pointer` tests

### DIFF
--- a/src/eravm_error.rs
+++ b/src/eravm_error.rs
@@ -23,6 +23,8 @@ pub enum EraVmError {
     HeapError(#[from] HeapError),
     #[error("Non Valid Forwarded Memory")]
     NonValidForwardedMemory,
+    #[error("Non Valid Program Counter")]
+    NonValidProgramCounter,
 }
 
 #[derive(Error, Debug)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -357,7 +357,10 @@ impl VMState {
     pub fn get_opcode(&self, opcode_table: &[OpcodeVariant]) -> Result<Opcode, EraVmError> {
         let current_context = self.current_frame()?;
         let pc = current_context.pc;
-        let raw_opcode = current_context.code_page[(pc / 4) as usize];
+        let raw_opcode = *current_context
+            .code_page
+            .get((pc / 4) as usize)
+            .ok_or(EraVmError::NonValidProgramCounter)?;
         let raw_opcode_64 = match pc % 4 {
             3 => (raw_opcode & u64::MAX.into()).as_u64(),
             2 => ((raw_opcode >> 64) & u64::MAX.into()).as_u64(),


### PR DESCRIPTION
The problem was the following:
> thread '<unnamed>' panicked at era_vm/src/state.rs:360:51:
> index out of bounds: the len is 119 but the index is 1343

Throwing an error for this case fixes the tests.

To run these tests:
```sh
cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path tests/solidity/simple/internal_function_pointers
```