### PR TITLE
Fix `fat_ptr` tests

### DIFF
--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -66,6 +66,10 @@ pub fn get_forward_memory_pointer(
                 return Err(HeapError::StoreOutOfBounds.into());
             };
 
+            if pointer.offset != 0 {
+                return Err(HeapError::StoreOutOfBounds.into());
+            }
+
             let ergs_cost = match pointer_kind {
                 PointerSource::NewForHeap => {
                     pointer.page = vm.current_frame()?.heap_id;

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -66,10 +66,6 @@ pub fn get_forward_memory_pointer(
                 return Err(HeapError::StoreOutOfBounds.into());
             };
 
-            if is_pointer || pointer.offset != 0 {
-                return Err(HeapError::StoreOutOfBounds.into());
-            }
-
             let ergs_cost = match pointer_kind {
                 PointerSource::NewForHeap => {
                     pointer.page = vm.current_frame()?.heap_id;


### PR DESCRIPTION
Fixes the `fat_ptr` tests. 
When it is a pointer, instead of throwing an error, it does nothing, matching the behavior of `vm2`.
Also, I have run all other test suites of  `tests/solidity/simple` and it does not seem to break anything.
Run this command to test these tests:
```sh
cargo run --verbose --features lambda_vm --release --bin compiler-tester -- --path tests/solidity/simple/fat_ptr
```