### PR TITLE
Fix handling of ERGS costs when expanding heap memory

### DIFF
--- a/src/eravm_error.rs
+++ b/src/eravm_error.rs
@@ -67,4 +67,6 @@ pub enum HeapError {
     StoreOutOfBounds,
     #[error("Trying to read outside of heap bounds")]
     ReadOutOfBounds,
+    #[error("Trying to read/write to heap caused growth which could not be affordable")]
+    NotEnoughErgsToGrowHeap,
 }

--- a/src/op_handlers/aux_heap_read.rs
+++ b/src/op_handlers/aux_heap_read.rs
@@ -22,7 +22,11 @@ pub fn aux_heap_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError
         .get_mut(vm.current_frame()?.aux_heap_id)
         .ok_or(HeapError::ReadOutOfBounds)?
         .expand_memory(addr + 32);
-    vm.current_frame_mut()?.gas_left -= gas_cost;
+
+    let out_of_gas = vm.decrease_gas(gas_cost)?;
+    if out_of_gas {
+        return Err(EraVmError::HeapError(HeapError::NotEnoughErgsToGrowHeap));
+    }
 
     let value = vm
         .heaps

--- a/src/op_handlers/aux_heap_write.rs
+++ b/src/op_handlers/aux_heap_write.rs
@@ -22,7 +22,11 @@ pub fn aux_heap_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmErro
         .get_mut(vm.current_frame()?.aux_heap_id)
         .ok_or(HeapError::ReadOutOfBounds)?
         .expand_memory(addr + 32);
-    vm.current_frame_mut()?.gas_left -= gas_cost;
+
+    let out_of_gas = vm.decrease_gas(gas_cost)?;
+    if out_of_gas {
+        return Err(EraVmError::HeapError(HeapError::NotEnoughErgsToGrowHeap));
+    }
 
     vm.heaps
         .get_mut(vm.current_frame()?.aux_heap_id)

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -20,7 +20,12 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmEr
 
         let gas_cost = heap.expand_memory(pointer.start + pointer.offset + 32);
         let value = heap.read_from_pointer(&pointer);
-        vm.current_frame_mut()?.gas_left -= gas_cost;
+
+        let out_of_gas = vm.decrease_gas(gas_cost)?;
+        if out_of_gas {
+            return Err(EraVmError::HeapError(HeapError::NotEnoughErgsToGrowHeap));
+        }
+
         value
     } else {
         U256::zero()

--- a/src/op_handlers/heap_read.rs
+++ b/src/op_handlers/heap_read.rs
@@ -21,14 +21,19 @@ pub fn heap_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
         .heaps
         .get_mut(vm.current_frame()?.heap_id)
         .ok_or(HeapError::StoreOutOfBounds)?
-        .expand_memory(addr + 32); // TODO: Handle ergs cost
-    vm.current_frame_mut()?.gas_left -= gas_cost;
+        .expand_memory(addr + 32);
+
+    let out_of_gas = vm.decrease_gas(gas_cost)?;
+    if out_of_gas {
+        return Err(EraVmError::HeapError(HeapError::NotEnoughErgsToGrowHeap));
+    }
 
     let value = vm
         .heaps
         .get(vm.current_frame()?.heap_id)
         .ok_or(HeapError::ReadOutOfBounds)?
         .read(addr);
+
     vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));
 
     if opcode.alters_vm_flags {

--- a/src/op_handlers/heap_write.rs
+++ b/src/op_handlers/heap_write.rs
@@ -22,7 +22,11 @@ pub fn heap_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
         .get_mut(vm.current_frame()?.heap_id)
         .ok_or(HeapError::StoreOutOfBounds)?
         .expand_memory(addr + 32);
-    vm.current_frame_mut()?.gas_left -= gas_cost;
+
+    let out_of_gas = vm.decrease_gas(gas_cost)?;
+    if out_of_gas {
+        return Err(EraVmError::HeapError(HeapError::NotEnoughErgsToGrowHeap));
+    }
 
     vm.heaps
         .get_mut(vm.current_frame()?.heap_id)


### PR DESCRIPTION
Fixes #110. We were previously mishandling ERGS costs. Now, if the VM runs out of gas during gas cost calculation, we return an error to ensure the error handler triggers a revert.