### PR TITLE
Implement Invalid opcode

### DIFF
--- a/src/eravm_error.rs
+++ b/src/eravm_error.rs
@@ -23,6 +23,8 @@ pub enum EraVmError {
     HeapError(#[from] HeapError),
     #[error("Non Valid Forwarded Memory")]
     NonValidForwardedMemory,
+    #[error("Invalid OpCode")]
+    InvalidOpCode,
 }
 
 #[derive(Error, Debug)]

--- a/src/eravm_error.rs
+++ b/src/eravm_error.rs
@@ -23,8 +23,8 @@ pub enum EraVmError {
     HeapError(#[from] HeapError),
     #[error("Non Valid Forwarded Memory")]
     NonValidForwardedMemory,
-    #[error("Invalid OpCode")]
-    InvalidOpCode,
+    #[error("Opcode error: {0}")]
+    OpcodeError(#[from] OpcodeError),
 }
 
 #[derive(Error, Debug)]
@@ -69,4 +69,10 @@ pub enum HeapError {
     StoreOutOfBounds,
     #[error("Trying to read outside of heap bounds")]
     ReadOutOfBounds,
+}
+
+#[derive(Error, Debug)]
+pub enum OpcodeError {
+    #[error("Invalid OpCode")]
+    InvalidOpCode,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub fn run(
 
         if vm.predicate_holds(&opcode.predicate) {
             let result = match opcode.variant {
-                Variant::Invalid(_) => todo!(),
+                Variant::Invalid(_) => Err(EraVmError::InvalidOpCode),
                 Variant::Nop(_) => {
                     address_operands_read(&mut vm, &opcode)?;
                     address_operands_store(&mut vm, &opcode, TaggedValue::new_raw_integer(0.into()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod utils;
 pub mod value;
 
 use address_operands::{address_operands_read, address_operands_store};
-use eravm_error::{EraVmError, HeapError};
+use eravm_error::{EraVmError, HeapError, OpcodeError};
 use op_handlers::add::add;
 use op_handlers::and::and;
 use op_handlers::aux_heap_read::aux_heap_read;
@@ -150,7 +150,7 @@ pub fn run(
 
         if vm.predicate_holds(&opcode.predicate) {
             let result = match opcode.variant {
-                Variant::Invalid(_) => Err(EraVmError::InvalidOpCode),
+                Variant::Invalid(_) => Err(EraVmError::OpcodeError(OpcodeError::InvalidOpCode)),
                 Variant::Nop(_) => {
                     address_operands_read(&mut vm, &opcode)?;
                     address_operands_store(&mut vm, &opcode, TaggedValue::new_raw_integer(0.into()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub fn run(
 
         if vm.predicate_holds(&opcode.predicate) {
             let result = match opcode.variant {
-                Variant::Invalid(_) => Err(EraVmError::OpcodeError(OpcodeError::InvalidOpCode)),
+                Variant::Invalid(_) => Err(OpcodeError::InvalidOpCode.into()),
                 Variant::Nop(_) => {
                     address_operands_read(&mut vm, &opcode)?;
                     address_operands_store(&mut vm, &opcode, TaggedValue::new_raw_integer(0.into()))


### PR DESCRIPTION
The spec doesn't mention how to handle the invalid opcode. The vm2 stops the execution altogether. In our case, we return an Err and let the `handleError` run.