### PR TITLE
fix: llvm/stack tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
       fail-fast: false
       matrix:
         testgroup: [
-          #tests/llvm/stack, # FAILING
           #tests/solidity/complex/defi, # FAILING
           #tests/solidity/complex/interpreter, # FAILING
           #tests/solidity/complex/parser, # FAILING
@@ -83,7 +82,7 @@ jobs:
           #tests/yul/near_call_abi/*.yul, # FAILING
           #tests/yul/near_call_abi/panic, # FAILING
           #tests/yul/precompiles, # FAILING
-          "tests/llvm/{intrinsics,load,memset,signed-operations,store,*.ll}", # PASSING
+          tests/llvm, # PASSING
           "tests/solidity/complex/array_one_element,balance,call_by_signature,call_chain,create,default,default_single_file,evaluation_order,forwarding,immutable_delegate_call,import_library_inline,indirect_recursion_fact,interface_casting,internal_function_pointers,invalid_signature,library_call_tuple,many_arguments,nested_calls,solidity_by_example}", # PASSING
           "tests/solidity/complex/{storage,sum_of_squares,try_catch,value,voting}", # PASSING
           "tests/solidity/complex/yul_instructions/{calldatasize,extcodehash,extcodesize}", # PASSING

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -11,7 +11,7 @@ pub struct CallFrame {
     pub transient_storage: Box<InMemory>,
     pub gas_left: Saturating<u32>,
     pub exception_handler: u64,
-    pub sp: u16,
+    pub sp: u32,
     pub storage_before: InMemory,
 }
 
@@ -95,7 +95,7 @@ impl CallFrame {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new_near_call_frame(
-        sp: u16,
+        sp: u32,
         pc: u64,
         gas_stipend: u32,
         transient_storage: Box<InMemory>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -426,21 +426,22 @@ impl Stack {
         }
     }
 
-    pub fn get_with_offset(&self, offset: usize, sp: u16) -> Result<TaggedValue, StackError> {
-        let sp = sp as usize;
-        if offset > sp || offset == 0 {
+    pub fn get_with_offset(&self, offset: u16, sp: u32) -> Result<TaggedValue, StackError> {
+        if offset as u32 > sp || offset == 0 {
             return Err(StackError::ReadOutOfBounds);
         }
-        if sp - offset >= self.stack.len() {
+        let index = (sp - offset as u32) as usize;
+        if index >= self.stack.len() {
             return Ok(TaggedValue::default());
         }
-        Ok(self.stack[sp - offset])
+        Ok(self.stack[index])
     }
 
-    pub fn get_absolute(&self, index: usize, sp: u16) -> Result<TaggedValue, StackError> {
-        if index >= sp as usize {
+    pub fn get_absolute(&self, index: u16, sp: u32) -> Result<TaggedValue, StackError> {
+        if index as u32 >= sp {
             return Err(StackError::ReadOutOfBounds);
         }
+        let index = index as usize;
         if index >= self.stack.len() {
             return Ok(TaggedValue::default());
         }
@@ -449,22 +450,23 @@ impl Stack {
 
     pub fn store_with_offset(
         &mut self,
-        offset: usize,
+        offset: u16,
         value: TaggedValue,
-        sp: u16,
+        sp: u32,
     ) -> Result<(), StackError> {
-        let sp = sp as usize;
-        if offset > sp || offset == 0 {
+        if offset as u32 > sp || offset == 0 {
             return Err(StackError::StoreOutOfBounds);
         }
-        if sp - offset >= self.stack.len() {
-            self.fill_with_zeros(sp - offset - self.stack.len() + 1);
+        let index = (sp - offset as u32) as usize;
+        if index >= self.stack.len() {
+            self.fill_with_zeros(index - self.stack.len() + 1);
         }
-        self.stack[sp - offset] = value;
+        self.stack[index] = value;
         Ok(())
     }
 
-    pub fn store_absolute(&mut self, index: usize, value: TaggedValue) -> Result<(), StackError> {
+    pub fn store_absolute(&mut self, index: u16, value: TaggedValue) -> Result<(), StackError> {
+        let index = index as usize;
         if index >= self.stack.len() {
             self.fill_with_zeros(index - self.stack.len() + 1);
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,3 +9,33 @@ pub fn address_into_u256(address: H160) -> U256 {
 pub(crate) fn is_kernel(address: &H160) -> bool {
     address.0[..18].iter().all(|&byte| byte == 0)
 }
+
+pub trait LowUnsigned {
+    fn low_u64(&self) -> u64;
+
+    fn low_u32(&self) -> u32 {
+        (self.low_u64() & u32::MAX as u64) as u32
+    }
+
+    fn low_u16(&self) -> u16 {
+        (self.low_u64() & u16::MAX as u64) as u16
+    }
+}
+
+impl LowUnsigned for U256 {
+    fn low_u64(&self) -> u64 {
+        self.low_u64()
+    }
+}
+
+impl LowUnsigned for u64 {
+    fn low_u64(&self) -> u64 {
+        *self
+    }
+}
+
+impl LowUnsigned for u32 {
+    fn low_u64(&self) -> u64 {
+        *self as u64
+    }
+}


### PR DESCRIPTION
The primer and the ISA doc state for stack access the offset is computed
by taking the lowest 16 bits.
This commit creates a little trait to easily extract those from `U256`
and `u64`, as well as lowest 32 bits (for stack pointer, that is at most
u16::MAX+1 due to being the biggest stack address + 1).
Doing this fixes a panic when storing to the stack using big values.

Fixes some of the `llvm/stack` tests. The other ones are either buggy or
we need to remove a check that vm2 doesn't (or, possibly, both).