### PR TITLE
Fix yul semantics

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -469,7 +469,7 @@ impl Stack {
         value: TaggedValue,
         sp: u16,
     ) -> Result<(), StackError> {
-        if index >= sp as usize {
+        if index > sp as usize {
             return Err(StackError::StoreOutOfBounds);
         }
         if index >= self.stack.len() {


### PR DESCRIPTION
This PR fixes tests under `tests/solidity/simple/yul_semantics`

There is a function with 15 arguments, were the first 14 were stored on registers and the 15th was stored on the stack
A `context.sp` was done, and the argument was stored at that position on the stack, since we checked that the `index >= sp`we failed, changing that to only a `>` fixes the test