### PR TITLE
Fix code hash decommit on `far_call`

### DIFF
--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use u256::{H160, U256};
 use zkevm_opcode_defs::{
     ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW, FarCallOpcode,

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use u256::{H160, U256};
 use zkevm_opcode_defs::{
     ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW, FarCallOpcode,
@@ -8,7 +9,7 @@ use crate::{
     eravm_error::{EraVmError, HeapError},
     state::VMState,
     store::{Storage, StorageError, StorageKey},
-    utils::address_into_u256,
+    utils::{address_into_u256, is_kernel},
     value::{FatPointer, TaggedValue},
     Opcode,
 };
@@ -127,6 +128,74 @@ fn address_from_u256(register_value: &U256) -> H160 {
     H160::from_slice(&buffer[12..])
 }
 
+fn decommit_code_hash(
+    storage: &mut dyn Storage,
+    address: Address,
+    default_aa_code_hash: [u8; 32],
+    is_constructor_call: bool,
+) -> Result<U256, EraVmError> {
+    let deployer_system_contract_address =
+        Address::from_low_u64_be(DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW as u64);
+    let storage_key = StorageKey::new(deployer_system_contract_address, address_into_u256(address));
+
+    let code_info = storage
+        .storage_read(storage_key)?
+        .ok_or(StorageError::KeyNotPresent)?;
+    let mut code_info_bytes = [0; 32];
+    code_info.to_big_endian(&mut code_info_bytes);
+
+    const IS_CONSTRUCTED_FLAG_ON: u8 = 0;
+    const IS_CONSTRUCTED_FLAG_OFF: u8 = 1;
+
+    // Note that EOAs are considered constructed because their code info is all zeroes.
+    let is_constructed = match code_info_bytes[1] {
+        IS_CONSTRUCTED_FLAG_ON => true,
+        IS_CONSTRUCTED_FLAG_OFF => false,
+        _ => {
+            return Err(EraVmError::IncorrectBytecodeFormat);
+        }
+    };
+
+    // We won't mask the address if it belongs to kernel
+    let is_not_kernel = !is_kernel(&address);
+    let try_default_aa = is_not_kernel.then_some(default_aa_code_hash);
+
+    const CONTRACT_VERSION_FLAG: u8 = 1;
+    const BLOB_VERSION_FLAG: u8 = 2;
+
+    // The address aliasing contract implements Ethereum-like behavior of calls to EOAs
+    // returning successfully (and address aliasing when called from the bootloader).
+    // It makes sense that unconstructed code is treated as an EOA but for some reason
+    // a constructor call to constructed code is also treated as EOA.
+    code_info_bytes = match code_info_bytes[0] {
+        // There is an ERA VM contract stored in this address
+        CONTRACT_VERSION_FLAG => {
+            // If we pretend to call the constructor, and it hasn't been already constructed, then
+            // we proceed. In other case, we return default.
+            // If we pretend to call a normal function, and it has been already constructed, then
+            // we proceed. In other case, we return default.
+            if is_constructed == is_constructor_call {
+                try_default_aa.ok_or(StorageError::KeyNotPresent)?
+            } else {
+                code_info_bytes
+            }
+        }
+        // There is an EVM contract (blob) stored in this address (we need the interpreter)
+        BLOB_VERSION_FLAG => {
+            // This will change after 1.5 and evm_interpreter_code_hash should be used. Now there are the same.
+            try_default_aa.ok_or(StorageError::KeyNotPresent)?
+        }
+        // EOA: There is no code, so we return the default
+        _ if code_info == U256::zero() => try_default_aa.ok_or(StorageError::KeyNotPresent)?,
+        // Invalid
+        _ => return Err(EraVmError::IncorrectBytecodeFormat),
+    };
+
+    code_info_bytes[1] = 0;
+
+    Ok(U256::from_big_endian(&code_info_bytes))
+}
+
 pub fn far_call(
     vm: &mut VMState,
     opcode: &Opcode,
@@ -140,21 +209,12 @@ pub fn far_call(
 
     let abi = get_far_call_arguments(src0.value);
 
-    let deployer_system_contract_address =
-        Address::from_low_u64_be(DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW as u64);
-    let storage_key = StorageKey::new(
-        deployer_system_contract_address,
-        address_into_u256(contract_address),
-    );
-
-    let code_info = storage
-        .storage_read(storage_key)?
-        .ok_or(StorageError::KeyNotPresent)?;
-    let mut code_info_bytes = [0; 32];
-    code_info.to_big_endian(&mut code_info_bytes);
-
-    code_info_bytes[1] = 0;
-    let code_key: U256 = U256::from_big_endian(&code_info_bytes);
+    let code_key = decommit_code_hash(
+        storage,
+        contract_address,
+        vm.default_aa_code_hash,
+        abi.is_constructor_call,
+    )?;
 
     let FarCallParams {
         ergs_passed,

--- a/src/state.rs
+++ b/src/state.rs
@@ -41,6 +41,7 @@ pub struct VMStateBuilder {
     pub tx_number: u64,
     pub heaps: Heaps,
     pub events: Vec<Event>,
+    pub default_aa_code_hash: [u8; 32],
 }
 
 // On this specific struct, I prefer to have the actual values
@@ -58,6 +59,7 @@ impl Default for VMStateBuilder {
             tx_number: 0,
             heaps: Heaps::default(),
             events: vec![],
+            default_aa_code_hash: Default::default(),
         }
     }
 }
@@ -110,6 +112,11 @@ impl VMStateBuilder {
         self
     }
 
+    pub fn with_default_aa_code_hash(mut self, default_aa_code_hash: [u8; 32]) -> VMStateBuilder {
+        self.default_aa_code_hash = default_aa_code_hash;
+        self
+    }
+
     pub fn build(self) -> VMState {
         VMState {
             registers: self.registers,
@@ -122,6 +129,7 @@ impl VMStateBuilder {
             heaps: self.heaps,
             events: self.events,
             register_context_u128: 0,
+            default_aa_code_hash: self.default_aa_code_hash,
         }
     }
 }
@@ -142,6 +150,7 @@ pub struct VMState {
     pub heaps: Heaps,
     pub events: Vec<Event>,
     pub register_context_u128: u128,
+    pub default_aa_code_hash: [u8; 32],
 }
 
 // Totally arbitrary, probably we will have to change it later.
@@ -153,6 +162,7 @@ impl VMState {
         contract_address: H160,
         caller: H160,
         context_u128: u128,
+        default_aa_code_hash: [u8; 32],
     ) -> Self {
         let mut registers = [TaggedValue::default(); 15];
         let calldata_ptr = FatPointer {
@@ -191,6 +201,7 @@ impl VMState {
             heaps,
             events: vec![],
             register_context_u128: context_u128,
+            default_aa_code_hash,
         }
     }
 

--- a/src/tracers/last_state_saver_tracer.rs
+++ b/src/tracers/last_state_saver_tracer.rs
@@ -14,7 +14,14 @@ pub struct LastStateSaverTracer {
 impl LastStateSaverTracer {
     pub fn new() -> Self {
         Self {
-            vm_state: VMState::new(vec![], vec![], H160::zero(), H160::zero(), 0_u128),
+            vm_state: VMState::new(
+                vec![],
+                vec![],
+                H160::zero(),
+                H160::zero(),
+                0_u128,
+                Default::default(),
+            ),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,3 +5,7 @@ pub fn address_into_u256(address: H160) -> U256 {
     buffer[12..].copy_from_slice(address.as_bytes());
     U256::from_big_endian(&buffer)
 }
+
+pub(crate) fn is_kernel(address: &H160) -> bool {
+    address.0[..18].iter().all(|&byte| byte == 0)
+}


### PR DESCRIPTION
#### Description

Previously we were not decommiting contract addressess properly on `far_call`. Now, with this PR (based on fix-f6 branch), we are performing some checks when a decommit is done, which will mask the code hash replacing it with the default account code hash, if corresponds.

It also adds a new configuration parameter `default_aa_code_hash` to the creation of `VMState`. Since this change updates the API, it will break the current era compiler tester adapter for the lambda vm. [This PR](https://github.com/lambdaclass/era-compiler-tester/pull/7) updates that adapter to cope with changes. 



