### PR TITLE
Fix complex/yul instructions/codecopy-calldatacopy-calldataload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
           #tests/solidity/complex/defi, # FAILING
           #tests/solidity/complex/interpreter, # FAILING
           #tests/solidity/complex/parser, # FAILING
-          #tests/solidity/complex/yul_instructions/calldatacopy, # FAILING
-          #tests/solidity/complex/yul_instructions/calldataload, # FAILING
-          #tests/solidity/complex/yul_instructions/codecopy, # FAILING
           #tests/solidity/ethereum/array/invalid_encoding_for_storage_byte_array.sol, # FAILING
           #tests/solidity/ethereum/constructor, # FAILING
           #tests/solidity/ethereum/externalContracts, # FAILING
@@ -87,8 +84,11 @@ jobs:
           "tests/solidity/complex/{storage,sum_of_squares,try_catch,value,voting}", # PASSING
           "tests/solidity/complex/yul_instructions/{calldatasize,extcodehash,extcodesize}", # PASSING
           tests/solidity/complex/yul_instructions/call/, # PASSING
+          tests/solidity/complex/yul_instructions/calldatacopy, # PASSING
+          tests/solidity/complex/yul_instructions/calldataload, # PASSING
           tests/solidity/complex/yul_instructions/create, # PASSING
           tests/solidity/complex/yul_instructions/create2, # PASSING
+          tests/solidity/complex/yul_instructions/codecopy, # PASSING
           tests/solidity/complex/yul_instructions/delegatecall, # PASSING
           tests/solidity/complex/yul_instructions/staticcall, # PASSING
           tests/solidity/ethereum/*.sol, # PASSING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           tests/llvm/intrinsics tests/llvm/load tests/llvm/memset tests/llvm/signed-operations tests/llvm/store, # PASSING
           tests/solidity/complex/array_one_element tests/solidity/complex/call_by_signature tests/solidity/complex/call_chain tests/solidity/complex/default tests/solidity/complex/default_single_file tests/solidity/complex/import_library_inline tests/solidity/complex/indirect_recursion_fact tests/solidity/complex/many_arguments tests/solidity/complex/storage tests/solidity/complex/sum_of_squares, # PASSING
           tests/solidity/complex/yul_instructions/balance, # PASSING
-          tests/solidity/complex/yul_instructions/call, # PASSING
+          tests/solidity/complex/yul_instructions/call/, # PASSING
           tests/solidity/complex/yul_instructions/calldatasize tests/solidity/complex/yul_instructions/extcodehash tests/solidity/complex/yul_instructions/extcodesize, # PASSING
           tests/solidity/complex/yul_instructions/create, # PASSING
           tests/solidity/complex/yul_instructions/create2, # PASSING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,9 @@ jobs:
           #tests/solidity/complex/defi, # FAILING
           #tests/solidity/complex/interpreter, # FAILING
           #tests/solidity/complex/parser, # FAILING
-          #tests/solidity/complex/solidity_by_example, # FAILING
-          #tests/solidity/complex/try_catch, # FAILING
-          #tests/solidity/complex/value, # FAILING
-          #tests/solidity/complex/voting, # FAILING
+          #tests/solidity/complex/yul_instructions/calldatacopy, # FAILING
+          #tests/solidity/complex/yul_instructions/calldataload, # FAILING
+          #tests/solidity/complex/yul_instructions/codecopy, # FAILING
           #tests/solidity/ethereum/array/invalid_encoding_for_storage_byte_array.sol, # FAILING
           #tests/solidity/ethereum/constructor, # FAILING
           #tests/solidity/ethereum/externalContracts, # FAILING
@@ -83,79 +82,31 @@ jobs:
           #tests/yul/near_call_abi/*.yul, # FAILING
           #tests/yul/near_call_abi/panic, # FAILING
           #tests/yul/precompiles, # FAILING
-          #tests/yul/semantic, # FAILING
-          tests/llvm/intrinsics tests/llvm/load tests/llvm/memset tests/llvm/signed-operations tests/llvm/store, # PASSING
-          tests/solidity/complex/array_one_element tests/solidity/complex/call_by_signature tests/solidity/complex/call_chain tests/solidity/complex/default tests/solidity/complex/default_single_file tests/solidity/complex/import_library_inline tests/solidity/complex/indirect_recursion_fact tests/solidity/complex/many_arguments tests/solidity/complex/storage tests/solidity/complex/sum_of_squares, # PASSING
-          tests/solidity/complex/yul_instructions/balance, # PASSING
+          "tests/llvm/{intrinsics,load,memset,signed-operations,store,*.ll}", # PASSING
+          "tests/solidity/complex/array_one_element,balance,call_by_signature,call_chain,create,default,default_single_file,evaluation_order,forwarding,immutable_delegate_call,import_library_inline,indirect_recursion_fact,interface_casting,internal_function_pointers,invalid_signature,library_call_tuple,many_arguments,nested_calls,solidity_by_example}", # PASSING
+          "tests/solidity/complex/{storage,sum_of_squares,try_catch,value,voting}", # PASSING
+          "tests/solidity/complex/yul_instructions/{calldatasize,extcodehash,extcodesize}", # PASSING
           tests/solidity/complex/yul_instructions/call/, # PASSING
-          tests/solidity/complex/yul_instructions/calldatacopy, # PASSING
-          tests/solidity/complex/yul_instructions/calldataload, # PASSING
-          tests/solidity/complex/yul_instructions/calldatasize tests/solidity/complex/yul_instructions/extcodehash tests/solidity/complex/yul_instructions/extcodesize, # PASSING
           tests/solidity/complex/yul_instructions/create, # PASSING
           tests/solidity/complex/yul_instructions/create2, # PASSING
-          tests/solidity/complex/yul_instructions/codecopy, # PASSING
           tests/solidity/complex/yul_instructions/delegatecall, # PASSING
-          tests/solidity/complex/interface_casting, # PASSING
-          tests/solidity/complex/nested_calls, # PASSING
           tests/solidity/complex/yul_instructions/staticcall, # PASSING
-          tests/solidity/ethereum/array/concat tests/solidity/ethereum/array/push tests/solidity/ethereum/array/slices, # PASSING
-          tests/solidity/ethereum/accessor tests/solidity/ethereum/asmForLoop tests/solidity/ethereum/builtinFunctions tests/solidity/ethereum/c99_scoping_activation.sol tests/solidity/ethereum/cleanup tests/solidity/ethereum/constantEvaluator, # PASSING
-          tests/solidity/ethereum/constants, # PASSING
-          tests/solidity/ethereum/constructor_*.sol, # PASSING
-          tests/solidity/ethereum/conversions, # PASSING
-          tests/solidity/ethereum/deployedCodeExclusion, # PASSING
-          tests/solidity/ethereum/dirty_calldata_bytes.sol, # PASSING
-          tests/solidity/ethereum/dirty_calldata_dynamic_array.sol, # PASSING
-          tests/solidity/ethereum/ecrecover, # PASSING
-          tests/solidity/ethereum/emit_three_identical_events.sol, # PASSING
-          tests/solidity/ethereum/emit_two_identical_events.sol, # PASSING
-          tests/solidity/ethereum/empty_contract.sol, # PASSING
-          tests/solidity/ethereum/empty_for_loop.sol, # PASSING
-          tests/solidity/ethereum/experimental, # PASSING
-          tests/solidity/ethereum/exponentiation, # PASSING
-          tests/solidity/ethereum/expressions, # PASSING
-          tests/solidity/ethereum/externalSource, # PASSING
-          tests/solidity/ethereum/fallback, # PASSING
-          tests/solidity/ethereum/functionSelector, # PASSING
-          tests/solidity/ethereum/getters, # PASSING
-          tests/solidity/ethereum/integer, # PASSING
-          tests/solidity/ethereum/interfaceID, # PASSING
-          tests/solidity/ethereum/interface_inheritance_conversions.sol, # PASSING
-          tests/solidity/ethereum/isoltestFormatting.sol, # PASSING
-          tests/solidity/ethereum/metaTypes, # PASSING
-          tests/solidity/ethereum/multiSource, # PASSING
-          tests/solidity/ethereum/optimizer, # PASSING
-          tests/solidity/ethereum/receive, # PASSING
-          tests/solidity/ethereum/salted_create, # PASSING
-          tests/solidity/ethereum/shanghai, # PASSING
-          tests/solidity/ethereum/specialFunctions, # PASSING
-          tests/solidity/ethereum/state, # PASSING
-          tests/solidity/ethereum/state_var_initialization.sol, # PASSING
-          tests/solidity/ethereum/state_variables_init_order.sol, # PASSING
-          tests/solidity/ethereum/state_variables_init_order_2.sol, # PASSING
-          tests/solidity/ethereum/state_variables_init_order_3.sol, # PASSING
-          tests/solidity/ethereum/statements, # PASSING
-          tests/solidity/ethereum/storage, # PASSING
-          tests/solidity/ethereum/underscore, # PASSING
-          tests/solidity/ethereum/unused_store_storage_removal_bug.sol, # PASSING
-          tests/solidity/ethereum/variables, # PASSING
-          tests/solidity/ethereum/virtualFunctions, # PASSING
-          tests/solidity/simple/algorithm, # PASSING
-          tests/solidity/simple/array, # PASSING
-          tests/solidity/simple/call_chain, # PASSING
-          tests/solidity/simple/conditional, # PASSING
-          tests/solidity/simple/error, # PASSING
-          tests/solidity/simple/expression, # PASSING
-          tests/solidity/simple/fat_ptr, # PASSING
-          tests/solidity/simple/function, # PASSING
-          tests/solidity/simple/gas_value, # PASSING
-          tests/solidity/simple/immutable, # PASSING
-          tests/solidity/simple/internal_function_pointers, # PASSING
-          tests/solidity/simple/modular, # PASSING
-          tests/solidity/simple/overflow, # PASSING
-          tests/solidity/simple/solidity_by_example, # PASSING
-          tests/solidity/simple/try_catch, # PASSING
-          tests/solidity/simple/yul_semantic, # PASSING
+          tests/solidity/ethereum/*.sol, # PASSING
+          "tests/solidity/ethereum/{abiEncoderV[12],abiencodedecode}", # PASSING
+          "tests/solidity/ethereum/{accessor,arithmetics,asmForLoop,builtinFunctions,c99_scoping_activation.sol,cleanup,constantEvaluator}", # PASSING
+          "tests/solidity/ethereum/array/{[a-hj-z]*.sol,inline_*.sol,array_memory_allocation,concat,push,slices}", # PASSING
+          tests/solidity/ethereum/array/copying, # PASSING
+          "tests/solidity/ethereum/array/{delete,indexAccess,pop}", # PASSING
+          "tests/solidity/ethereum/{calldata,constants,conversions,deployedCodeExclusion,ecrecover,enums,errors}", # PASSING
+          "tests/solidity/ethereum/{events,experimental,exponentiation,expressions,externalSource}", # PASSING
+          "tests/solidity/ethereum/{fallback,freeFunctions,functionSelector,functionTypes}", # PASSING
+          "tests/solidity/ethereum/{getters,immutable,inheritance,integer,interfaceID,isoltestTesting}", # PASSING
+          "tests/solidity/ethereum/{libraries,literals,memoryManagement,metaTypes,multiSource}", # PASSING
+          "tests/solidity/ethereum/{operators,optimizer,receive}", # PASSING
+          "tests/solidity/ethereum/{revertStrings,salted_create,shanghai,smoke,specialFunctions,state}", # PASSING
+          "tests/solidity/ethereum/{statements,storage,strings,structs}", # PASSING
+          "tests/solidity/ethereum/{types,underscore,using,variables,virtualFunctions}", # PASSING
+          tests/solidity/ethereum/viaYul, # PASSING
           tests/solidity/simple/*.sol, # PASSING
           "tests/solidity/simple/{algorithm,array,block,call_chain,conditional,constant_expressions,constants,constructor,context}", # PASSING
           "tests/solidity/simple/{destructuring,error,events,expression,fallback,fat_ptr,function,gas_value,immutable,interface,internal_function_pointers}", # PASSING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
           #tests/solidity/complex/try_catch, # FAILING
           #tests/solidity/complex/value, # FAILING
           #tests/solidity/complex/voting, # FAILING
-          #tests/solidity/complex/yul_instructions/calldatacopy, # FAILING
-          #tests/solidity/complex/yul_instructions/calldataload, # FAILING
-          #tests/solidity/complex/yul_instructions/codecopy, # FAILING
           #tests/solidity/ethereum/array/invalid_encoding_for_storage_byte_array.sol, # FAILING
           #tests/solidity/ethereum/constructor, # FAILING
           #tests/solidity/ethereum/externalContracts, # FAILING
@@ -91,9 +88,12 @@ jobs:
           tests/solidity/complex/array_one_element tests/solidity/complex/call_by_signature tests/solidity/complex/call_chain tests/solidity/complex/default tests/solidity/complex/default_single_file tests/solidity/complex/import_library_inline tests/solidity/complex/indirect_recursion_fact tests/solidity/complex/many_arguments tests/solidity/complex/storage tests/solidity/complex/sum_of_squares, # PASSING
           tests/solidity/complex/yul_instructions/balance, # PASSING
           tests/solidity/complex/yul_instructions/call/, # PASSING
+          tests/solidity/complex/yul_instructions/calldatacopy, # PASSING
+          tests/solidity/complex/yul_instructions/calldataload, # PASSING
           tests/solidity/complex/yul_instructions/calldatasize tests/solidity/complex/yul_instructions/extcodehash tests/solidity/complex/yul_instructions/extcodesize, # PASSING
           tests/solidity/complex/yul_instructions/create, # PASSING
           tests/solidity/complex/yul_instructions/create2, # PASSING
+          tests/solidity/complex/yul_instructions/codecopy, # PASSING
           tests/solidity/complex/yul_instructions/delegatecall, # PASSING
           tests/solidity/complex/interface_casting, # PASSING
           tests/solidity/complex/nested_calls, # PASSING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,9 @@ jobs:
           #tests/solidity/complex/try_catch, # FAILING
           #tests/solidity/complex/value, # FAILING
           #tests/solidity/complex/voting, # FAILING
-          #tests/solidity/complex/yul_instructions/call, # FAILING
           #tests/solidity/complex/yul_instructions/calldatacopy, # FAILING
           #tests/solidity/complex/yul_instructions/calldataload, # FAILING
           #tests/solidity/complex/yul_instructions/codecopy, # FAILING
-          #tests/solidity/complex/yul_instructions/delegatecall, # FAILING
           #tests/solidity/complex/yul_instructions/staticcall, # FAILING
           #tests/solidity/ethereum/abiEncoderV1, # FAILING
           #tests/solidity/ethereum/abiEncoderV2, # FAILING
@@ -212,9 +210,11 @@ jobs:
           tests/llvm/intrinsics tests/llvm/load tests/llvm/memset tests/llvm/signed-operations tests/llvm/store, # PASSING
           tests/solidity/complex/array_one_element tests/solidity/complex/call_by_signature tests/solidity/complex/call_chain tests/solidity/complex/default tests/solidity/complex/default_single_file tests/solidity/complex/import_library_inline tests/solidity/complex/indirect_recursion_fact tests/solidity/complex/many_arguments tests/solidity/complex/storage tests/solidity/complex/sum_of_squares, # PASSING
           tests/solidity/complex/yul_instructions/balance, # PASSING
+          tests/solidity/complex/yul_instructions/call, # PASSING
           tests/solidity/complex/yul_instructions/calldatasize tests/solidity/complex/yul_instructions/extcodehash tests/solidity/complex/yul_instructions/extcodesize, # PASSING
           tests/solidity/complex/yul_instructions/create, # PASSING
           tests/solidity/complex/yul_instructions/create2, # PASSING
+          tests/solidity/complex/yul_instructions/delegatecall, # PASSING
           tests/solidity/complex/interface_casting, # PASSING
           tests/solidity/complex/nested_calls, # PASSING
           tests/solidity/ethereum/array/concat tests/solidity/ethereum/array/push tests/solidity/ethereum/array/slices, # PASSING

--- a/src/eravm_error.rs
+++ b/src/eravm_error.rs
@@ -79,6 +79,8 @@ pub enum HeapError {
     StoreOutOfBounds,
     #[error("Trying to read outside of heap bounds")]
     ReadOutOfBounds,
+    #[error("Trying to read at invalid address")]
+    InvalidAddress,
 }
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,15 @@ pub fn run(
             tracer.before_execution(&opcode, &mut vm)?;
         }
 
-        if let Some(_err) = vm.decrease_gas(opcode.gas_cost).err() {
+        let can_execute = vm.can_execute(&opcode);
+        if vm.decrease_gas(opcode.gas_cost).is_err() || can_execute.is_err() {
             match inexplicit_panic(&mut vm, storage) {
                 Ok(false) => continue,
                 _ => return Ok((ExecutionOutput::Panic, vm)),
             }
         }
 
-        if vm.can_execute(&opcode)? {
+        if can_execute.unwrap() {
             let result = match opcode.variant {
                 Variant::Invalid(_) => Err(OpcodeError::InvalidOpCode.into()),
                 Variant::Nop(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ pub fn run(
                 },
                 Variant::FarCall(far_call_variant) => {
                     let res = far_call(&mut vm, &opcode, &far_call_variant, storage);
-                    if let Err(_) = res {
+                    if res.is_err() {
                         panic_from_far_call(&mut vm, &opcode)?;
                         continue;
                     }

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -102,10 +102,10 @@ fn far_call_params_from_register(
     let mut ergs_passed = source.0[3] as u32;
     let gas_left = vm.gas_left()?;
 
-    if ergs_passed > gas_left {
-        ergs_passed = (gas_left * FAR_CALL_GAS_SCALAR_MODIFIER_DIVIDEND)
-            / FAR_CALL_GAS_SCALAR_MODIFIER_DIVISOR;
-    }
+    let maximum_gas =
+        gas_left / FAR_CALL_GAS_SCALAR_MODIFIER_DIVISOR * FAR_CALL_GAS_SCALAR_MODIFIER_DIVIDEND;
+    ergs_passed = ergs_passed.min(maximum_gas);
+
     source.to_little_endian(&mut args);
     let [.., shard_id, constructor_call_byte, system_call_byte] = args;
 

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -10,6 +10,13 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmEr
     if !src0.is_pointer {
         return Err(OperandError::InvalidSrcNotPointer(opcode.variant).into());
     }
+
+    // make sure the pointer is a value that can be added without overflow for 32 bits.
+    if src0.value.low_u32() > (u32::MAX - 32) {
+        let _ = vm.set_gas_left(0);
+        return Err(HeapError::InvalidAddress.into());
+    }
+
     let pointer = FatPointer::decode(src0.value);
 
     let value = if pointer.offset < pointer.len {

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -13,7 +13,7 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmEr
 
     // make sure the pointer is a value that can be added without overflow for 32 bits.
     if src0.value.low_u32() > (u32::MAX - 32) {
-        let _ = vm.set_gas_left(0);
+        vm.set_gas_left(0)?;
         return Err(HeapError::InvalidAddress.into());
     }
 

--- a/src/ptr_operator.rs
+++ b/src/ptr_operator.rs
@@ -1,5 +1,3 @@
-use zkevm_opcode_defs::MAX_OFFSET_FOR_ADD_SUB;
-
 use crate::{
     address_operands::{address_operands_read, address_operands_store},
     eravm_error::{EraVmError, OperandError},
@@ -19,7 +17,7 @@ pub fn ptr_operands_read(
     }
 
     let pointer = FatPointer::decode(src0.value);
-    if src1.value > MAX_OFFSET_FOR_ADD_SUB {
+    if src1.value > u32::MAX.into() {
         return Err(OperandError::Src1TooLarge(opcode.variant).into());
     }
     let diff = src1.value.low_u32();


### PR DESCRIPTION
Fixes all remaining tests under:
- `solidity/complex/yul instructions/codecopy`
- `solidity/complex/yul instructions/calldatacopy`
- `solidity/complex/yul instructions/calldataload`

They were failing because: 
- we were not validating if the address could overflow when doing `fat_ptr read`,
- we were not properly validating if the operands sources were larger than u32 when fetching ptr operators.
