### PR TITLE
Rename VM flags

### DIFF
--- a/src/address_operands.rs
+++ b/src/address_operands.rs
@@ -87,7 +87,7 @@ pub fn address_operands_read(
             }
         }
     };
-    if opcode.swap_flag {
+    if opcode.flag1_set {
         Ok((op2, op1))
     } else {
         Ok((op1, op2))

--- a/src/op_handlers/add.rs
+++ b/src/op_handlers/add.rs
@@ -8,7 +8,7 @@ pub fn add(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = (src0_t.value, src1_t.value);
     // res = (src0 + src1) mod (2**256);
     let (res, overflow) = src0.overflowing_add(src1);
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // If overflow, set the flag.
         // otherwise keep the current value.
         vm.flag_lt_of = overflow;

--- a/src/op_handlers/and.rs
+++ b/src/op_handlers/and.rs
@@ -7,7 +7,7 @@ pub fn and(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = address_operands_read(vm, opcode)?;
 
     let res = src0.value & src1.value;
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Always cleared
         vm.flag_lt_of = false;
         // Set eq if res == 0

--- a/src/op_handlers/aux_heap_read.rs
+++ b/src/op_handlers/aux_heap_read.rs
@@ -32,7 +32,7 @@ pub fn aux_heap_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError
         .read(addr);
     vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));
 
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // This flag is set if .inc is present
         vm.set_register(
             opcode.dst1_index,

--- a/src/op_handlers/aux_heap_write.rs
+++ b/src/op_handlers/aux_heap_write.rs
@@ -30,7 +30,7 @@ pub fn aux_heap_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmErro
         .ok_or(HeapError::ReadOutOfBounds)?
         .store(addr, src1.value);
 
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // This flag is set if .inc is present
         vm.set_register(
             opcode.dst0_index,

--- a/src/op_handlers/div.rs
+++ b/src/op_handlers/div.rs
@@ -11,7 +11,7 @@ pub fn div(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let mut quotient = U256::zero();
     let mut remainder = U256::zero();
     if src1.is_zero() {
-        if opcode.alters_vm_flags {
+        if opcode.flag0_set {
             // Lt overflow is set
             vm.flag_lt_of = true;
             // Eq is set if resultlow is 0, in this case its always 0
@@ -21,7 +21,7 @@ pub fn div(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
         }
     } else {
         (quotient, remainder) = src0.div_mod(src1);
-        if opcode.alters_vm_flags {
+        if opcode.flag0_set {
             // Lt overflow is cleared
             vm.flag_lt_of = false;
             // Eq is set if quotient is zero

--- a/src/op_handlers/event.rs
+++ b/src/op_handlers/event.rs
@@ -15,7 +15,7 @@ pub fn event(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
         let event = Event {
             key,
             value,
-            is_first: opcode.alters_vm_flags,
+            is_first: opcode.flag0_set,
             shard_id: 1,
             tx_number: vm.tx_number as u16,
         };

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -231,7 +231,7 @@ pub fn far_call(
         .ok_or(StorageError::KeyNotPresent)?;
     let new_heap = vm.heaps.allocate();
     let new_aux_heap = vm.heaps.allocate();
-    let is_new_frame_static = opcode.alters_vm_flags || vm.current_context()?.is_static;
+    let is_new_frame_static = opcode.flag0_set || vm.current_context()?.is_static;
 
     match far_call {
         FarCallOpcode::Normal => {

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -37,7 +37,7 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmEr
 
     vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));
 
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // This flag is set if .inc is present
         let new_pointer = FatPointer {
             offset: pointer.offset + 32,

--- a/src/op_handlers/heap_read.rs
+++ b/src/op_handlers/heap_read.rs
@@ -33,7 +33,7 @@ pub fn heap_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
 
     vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));
 
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // This flag is set if .inc is present
         vm.set_register(
             opcode.dst1_index,

--- a/src/op_handlers/heap_write.rs
+++ b/src/op_handlers/heap_write.rs
@@ -30,7 +30,7 @@ pub fn heap_write(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
         .ok_or(HeapError::StoreOutOfBounds)?
         .store(addr, src1.value);
 
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // This flag is set if .inc is present
         vm.set_register(
             opcode.dst0_index,

--- a/src/op_handlers/mul.rs
+++ b/src/op_handlers/mul.rs
@@ -16,7 +16,7 @@ pub fn mul(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let low_bits = res & u256_mask;
     let high_bits = res >> 256 & u256_mask;
 
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Lt overflow, is set if
         // src0 * src1 >= 2^256
         let overflow = res >= U512::from(U256::MAX);

--- a/src/op_handlers/or.rs
+++ b/src/op_handlers/or.rs
@@ -7,7 +7,7 @@ pub fn or(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = address_operands_read(vm, opcode)?;
 
     let res = src0.value | src1.value;
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Always cleared
         vm.flag_lt_of = false;
         // Set eq if res == 0

--- a/src/op_handlers/ret.rs
+++ b/src/op_handlers/ret.rs
@@ -49,7 +49,7 @@ pub fn ret(
 
     if vm.in_near_call()? {
         let previous_frame = vm.pop_frame()?;
-        if opcode.alters_vm_flags {
+        if opcode.flag0_set {
             let to_label = opcode.imm0;
             vm.current_frame_mut()?.pc = to_label as u64;
         } else if is_failure {

--- a/src/op_handlers/shift.rs
+++ b/src/op_handlers/shift.rs
@@ -10,7 +10,7 @@ pub fn shl(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = src1 % 256;
     let res = src0 << shift;
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Eq is set if result == 0
         vm.flag_eq = res.is_zero();
         // other flags are reset
@@ -26,7 +26,7 @@ pub fn shr(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = src1 % 256;
     let res = src0 >> shift;
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Eq is set if result == 0
         vm.flag_eq = res.is_zero();
         // other flags are reset
@@ -42,7 +42,7 @@ pub fn rol(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = src1.low_u32() % 256;
     let result = (src0 << shift) | (src0 >> (256 - shift));
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Eq is set if result == 0
         vm.flag_eq = result.is_zero();
         // other flags are reset
@@ -58,7 +58,7 @@ pub fn ror(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = (src0_t.value, src1_t.value);
     let shift = src1.low_u32() % 256;
     let result = (src0 >> shift) | (src0 << (256 - shift));
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Eq is set if result == 0
         vm.flag_eq = result.is_zero();
         // other flags are reset

--- a/src/op_handlers/sub.rs
+++ b/src/op_handlers/sub.rs
@@ -9,7 +9,7 @@ pub fn sub(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = (src0_t.value, src1_t.value);
     // res = (src0 - src1) mod (2**256);
     let (res, overflow) = src0.overflowing_sub(src1);
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Overflow <-> src0 < src1
         vm.flag_lt_of = overflow;
         // Set eq if res == 0

--- a/src/op_handlers/xor.rs
+++ b/src/op_handlers/xor.rs
@@ -7,7 +7,7 @@ pub fn xor(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
     let (src0, src1) = address_operands_read(vm, opcode)?;
 
     let res = src0.value ^ src1.value;
-    if opcode.alters_vm_flags {
+    if opcode.flag0_set {
         // Always cleared
         vm.flag_lt_of = false;
         // Set eq if res == 0

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -35,8 +35,8 @@ pub struct Opcode {
     pub src0_operand_type: Operand,
     pub dst0_operand_type: Operand,
     pub predicate: Predicate,
-    pub alters_vm_flags: bool,
-    pub swap_flag: bool,
+    pub flag0_set: bool,
+    pub flag1_set: bool,
     pub src0_index: u8,
     pub src1_index: u8,
     pub dst0_index: u8,
@@ -51,7 +51,7 @@ impl Opcode {
         // First 11 bits
         let variant_bits = raw_op & 2047;
         let opcode_zksync = opcode_table[variant_bits as usize];
-        let [alters_vm_flags, swap_flag] = match opcode_zksync.opcode {
+        let [flag0_set, flag1_set] = match opcode_zksync.opcode {
             Variant::Ptr(_) => [false, opcode_zksync.flags[0]],
             _ => opcode_zksync.flags,
         };
@@ -69,8 +69,8 @@ impl Opcode {
             src0_operand_type: opcode_zksync.src0_operand_type,
             dst0_operand_type: opcode_zksync.dst0_operand_type,
             predicate: Predicate::from(predicate_u8),
-            alters_vm_flags,
-            swap_flag,
+            flag0_set,
+            flag1_set,
             src0_index: first_four_bits(src0_and_1_index),
             src1_index: second_four_bits(src0_and_1_index),
             dst0_index: first_four_bits(dst0_and_1_index),


### PR DESCRIPTION
Closes #151 

Current naming scheme for the two flags in the vm do not represent their actual use in some cases (see linked issue for more details).