### PR TITLE
Fix solidity/ethereum/inlineAssembly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
           #tests/solidity/complex/defi, # FAILING
           #tests/solidity/complex/interpreter, # FAILING
           #tests/solidity/complex/parser, # FAILING
-          #tests/solidity/ethereum/inlineAssembly, # FAILING
           #tests/yul/precompiles, # FAILING
           tests/llvm, # PASSING
           "tests/solidity/complex/array_one_element,balance,call_by_signature,call_chain,create,default,default_single_file,evaluation_order,forwarding,immutable_delegate_call,import_library_inline,indirect_recursion_fact,interface_casting,internal_function_pointers,invalid_signature,library_call_tuple,many_arguments,nested_calls,solidity_by_example}", # PASSING
@@ -81,7 +80,7 @@ jobs:
           "tests/solidity/ethereum/{calldata,constants,constructor,conversions,deployedCodeExclusion,ecrecover,enums,errors}", # PASSING
           "tests/solidity/ethereum/{events,experimental,exponentiation,expressions,externalContracts,externalSource}", # PASSING
           "tests/solidity/ethereum/{fallback,freeFunctions,functionCall,functionSelector,functionTypes}", # PASSING
-          "tests/solidity/ethereum/{getters,immutable,inheritance,integer,interfaceID,isoltestTesting}", # PASSING
+          "tests/solidity/ethereum/{getters,immutable,inheritance,inlineAssembly,integer,interfaceID,isoltestTesting}", # PASSING
           "tests/solidity/ethereum/{libraries,literals,memoryManagement,metaTypes,modifiers,multiSource}", # PASSING
           "tests/solidity/ethereum/{operators,optimizer,payable,receive}", # PASSING
           "tests/solidity/ethereum/{reverts,revertStrings,salted_create,shanghai,smoke,specialFunctions,state}", # PASSING

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -53,11 +53,17 @@ impl Context {
         calldata_heap_id: u32,
         exception_handler: u64,
         context_u128: u128,
+        transient_storage: Box<InMemory>,
         storage_before: InMemory,
         is_static: bool,
     ) -> Self {
         Self {
-            frame: CallFrame::new_far_call_frame(gas_stipend, exception_handler, storage_before),
+            frame: CallFrame::new_far_call_frame(
+                gas_stipend,
+                exception_handler,
+                storage_before,
+                transient_storage,
+            ),
             near_call_frames: vec![],
             contract_address,
             caller,
@@ -82,11 +88,12 @@ impl CallFrame {
         gas_stipend: u32,
         exception_handler: u64,
         storage_before: InMemory,
+        transient_storage: Box<InMemory>,
     ) -> Self {
         Self {
             pc: 0,
             gas_left: Saturating(gas_stipend),
-            transient_storage: Box::new(InMemory::new_empty()),
+            transient_storage,
             exception_handler,
             sp: 0,
             storage_before,
@@ -102,7 +109,6 @@ impl CallFrame {
         exception_handler: u64,
         storage_before: InMemory,
     ) -> Self {
-        let transient_storage = transient_storage.clone();
         Self {
             pc,
             gas_left: Saturating(gas_stipend),

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -208,6 +208,7 @@ pub fn far_call(
 
     let exception_handler = opcode.imm0 as u64;
     let storage_before = storage.fake_clone();
+    let transient_storage = vm.current_frame()?.transient_storage.clone();
 
     let mut abi = get_far_call_arguments(src0.value);
     abi.is_constructor_call = abi.is_constructor_call && vm.current_context()?.is_kernel();
@@ -246,6 +247,7 @@ pub fn far_call(
                 forward_memory.page,
                 exception_handler,
                 vm.register_context_u128,
+                transient_storage,
                 storage_before,
                 is_new_frame_static,
             )?;
@@ -271,6 +273,7 @@ pub fn far_call(
                 forward_memory.page,
                 exception_handler,
                 vm.register_context_u128,
+                transient_storage,
                 storage_before,
                 is_new_frame_static,
             )?;
@@ -290,6 +293,7 @@ pub fn far_call(
                 forward_memory.page,
                 exception_handler,
                 this_context.context_u128,
+                transient_storage,
                 storage_before,
                 is_new_frame_static,
             )?;

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -1,5 +1,3 @@
-use u256::U256;
-
 use crate::address_operands::address_operands_read;
 use crate::eravm_error::{EraVmError, HeapError, OperandError};
 use crate::value::{FatPointer, TaggedValue};

--- a/src/op_handlers/fat_pointer_read.rs
+++ b/src/op_handlers/fat_pointer_read.rs
@@ -1,3 +1,5 @@
+use u256::U256;
+
 use crate::address_operands::address_operands_read;
 use crate::eravm_error::{EraVmError, HeapError, OperandError};
 use crate::value::{FatPointer, TaggedValue};
@@ -17,14 +19,19 @@ pub fn fat_pointer_read(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmEr
 
     let pointer = FatPointer::decode(src0.value);
 
-    let heap = vm
-        .heaps
-        .get_mut(pointer.page)
-        .ok_or(HeapError::ReadOutOfBounds)?;
-    let gas_cost = heap.expand_memory(pointer.start + pointer.offset + 32);
-    let value = heap.read_from_pointer(&pointer);
+    let value = if pointer.offset < pointer.len {
+        let heap = vm
+            .heaps
+            .get_mut(pointer.page)
+            .ok_or(HeapError::ReadOutOfBounds)?;
+        let gas_cost = heap.expand_memory(pointer.start + pointer.offset + 32);
+        let value = heap.read_from_pointer(&pointer);
+        vm.decrease_gas(gas_cost)?;
 
-    vm.decrease_gas(gas_cost)?;
+        value
+    } else {
+        U256::zero()
+    };
 
     vm.set_register(opcode.dst0_index, TaggedValue::new_raw_integer(value));
 

--- a/src/op_handlers/ret.rs
+++ b/src/op_handlers/ret.rs
@@ -31,7 +31,7 @@ fn get_result(
     Ok(TaggedValue::new_pointer(FatPointer::encode(&result)))
 }
 
-fn save_transient_store(vm: &mut VMState, prev_storage: Box<InMemory>) {
+fn save_transient_store(vm: &mut VMState, prev_storage: InMemory) {
     let keys = prev_storage.get_all_keys();
     for key in keys {
         let value = prev_storage.storage_read(key).unwrap();
@@ -73,7 +73,7 @@ pub fn ret(
         }
         vm.current_frame_mut()?.gas_left += previous_frame.gas_left;
         if return_type == RetOpcode::Ok {
-            save_transient_store(vm, previous_frame.transient_storage);
+            save_transient_store(vm, *previous_frame.transient_storage);
         }
         Ok(false)
     } else if vm.in_far_call() {
@@ -90,7 +90,7 @@ pub fn ret(
         }
 
         if return_type == RetOpcode::Ok {
-            save_transient_store(vm, previous_frame.transient_storage);
+            save_transient_store(vm, *previous_frame.transient_storage);
         }
 
         Ok(false)

--- a/src/op_handlers/ret.rs
+++ b/src/op_handlers/ret.rs
@@ -36,8 +36,7 @@ fn save_transient_store(vm: &mut VMState, prev_storage: InMemory) -> Result<(), 
     for key in keys {
         let value = prev_storage.storage_read(key)?;
         if let Some(value) = value {
-            vm.current_frame_mut()
-                .unwrap()
+            vm.current_frame_mut()?
                 .transient_storage
                 .storage_write(key, value)?;
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -185,7 +185,7 @@ impl VMState {
             CALLDATA_HEAP,
             0,
             context_u128,
-            Box::new(InMemory::default()),
+            Box::default(),
             InMemory::default(),
             false,
         );

--- a/src/state.rs
+++ b/src/state.rs
@@ -519,13 +519,10 @@ impl Heap {
     }
 
     pub fn read_from_pointer(&self, pointer: &FatPointer) -> U256 {
-        let start: u32 = pointer.start + pointer.offset.min(pointer.len);
-        let end = start.saturating_add(32).min(pointer.start + pointer.len);
-
         let mut result = U256::zero();
         for i in 0..32 {
-            let addr = start + (31 - i);
-            if addr < end {
+            let addr = pointer.start + pointer.offset + (31 - i);
+            if addr < pointer.start + pointer.len {
                 result |= U256::from(self.heap[addr as usize]) << (i * 8);
             }
         }


### PR DESCRIPTION
They were failing because we were not properly storing the values in the transient storage between frames. Also, in the `fat_pointer_read` opcode we were incorrectly reading the values.