### PR TITLE
Implement aux_mutating0 opcode

### DIFF
--- a/src/op_handlers/context.rs
+++ b/src/op_handlers/context.rs
@@ -77,7 +77,8 @@ pub fn set_context_u128(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmEr
 }
 
 pub fn aux_mutating0(_vm: &mut VMState, _opcode: &Opcode) -> Result<(), EraVmError> {
-    panic!("Not yet implemented");
+    // does nothing for now
+    Ok(())
 }
 
 pub fn increment_tx_number(vm: &mut VMState, _opcode: &Opcode) -> Result<(), EraVmError> {


### PR DESCRIPTION
This opcode actually does nothing, shouldn't panic though, just increment pc. See [here](https://github.com/matter-labs/era-zk_evm/blob/v1.5.0/src/opcodes/execution/context.rs#L42C1-L47C1) and [here](https://github.com/matter-labs/vm2/blob/master/src/instruction_handlers/context.rs#L115-L123).