### PR TITLE
Various gas fixes

### DIFF
--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -9,6 +9,7 @@ pub struct CallFrame {
     pub pc: u64,
     pub transient_storage_snapshot: SnapShot,
     pub gas_left: Saturating<u32>,
+    pub stipend: Saturating<u32>,
     pub exception_handler: u64,
     pub sp: u32,
     pub storage_snapshot: SnapShot,
@@ -43,7 +44,8 @@ impl Context {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         program_code: Vec<U256>,
-        gas_stipend: u32,
+        new_context_gas: u32,
+        stipend: u32,
         contract_address: Address,
         code_address: Address,
         caller: Address,
@@ -58,7 +60,8 @@ impl Context {
     ) -> Self {
         Self {
             frame: CallFrame::new_far_call_frame(
-                gas_stipend,
+                new_context_gas,
+                stipend,
                 exception_handler,
                 storage_snapshot,
                 transient_storage_snapshot,
@@ -84,14 +87,16 @@ impl Context {
 
 impl CallFrame {
     pub fn new_far_call_frame(
-        gas_stipend: u32,
+        gas_left: u32,
+        stipend: u32,
         exception_handler: u64,
         storage_snapshot: SnapShot,
         transient_storage_snapshot: SnapShot,
     ) -> Self {
         Self {
             pc: 0,
-            gas_left: Saturating(gas_stipend),
+            gas_left: Saturating(gas_left),
+            stipend: Saturating(stipend),
             transient_storage_snapshot,
             exception_handler,
             sp: 0,
@@ -111,6 +116,7 @@ impl CallFrame {
         Self {
             pc,
             gas_left: Saturating(gas_stipend),
+            stipend: Saturating(0),
             transient_storage_snapshot,
             exception_handler,
             sp,

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -252,6 +252,7 @@ pub fn far_call(
             vm.push_far_call_frame(
                 program_code,
                 ergs_passed,
+                stipend,
                 contract_address,
                 contract_address,
                 vm.current_context()?.contract_address,
@@ -278,6 +279,7 @@ pub fn far_call(
             vm.push_far_call_frame(
                 program_code,
                 ergs_passed,
+                stipend,
                 contract_address,
                 contract_address,
                 H160::from(caller_bytes_20),
@@ -298,6 +300,7 @@ pub fn far_call(
             vm.push_far_call_frame(
                 program_code,
                 ergs_passed,
+                stipend,
                 contract_address,
                 this_contract_address,
                 this_context.caller,

--- a/src/op_handlers/ret.rs
+++ b/src/op_handlers/ret.rs
@@ -90,6 +90,8 @@ pub fn inexplicit_panic(
     state_storage: &mut StateStorage,
     transient_storage: &mut StateStorage,
 ) -> Result<bool, EraVmError> {
+    vm.decrease_gas(zkevm_opcode_defs::Opcode::Ret(RetOpcode::Panic).ergs_price())?;
+
     vm.flag_eq = false;
     vm.flag_lt_of = true;
     vm.flag_gt = false;
@@ -120,6 +122,8 @@ pub fn inexplicit_panic(
 // When executing a far_call, if the opcode fails, we need to run the exception handler provided in the args
 // We don't need to: run ret.panic, pop a frame and run its exception handler
 pub fn panic_from_far_call(vm: &mut VMState, opcode: &Opcode) -> Result<(), EraVmError> {
+    vm.decrease_gas(zkevm_opcode_defs::Opcode::Ret(RetOpcode::Panic).ergs_price())?;
+
     let far_call_exception_handler = opcode.imm0 as u64;
     let result = TaggedValue::new_pointer(U256::zero());
     vm.register_context_u128 = 0_u128;

--- a/src/op_handlers/ret.rs
+++ b/src/op_handlers/ret.rs
@@ -67,7 +67,7 @@ pub fn ret(
         vm.clear_registers();
         vm.set_register(1, result);
         let previous_frame = vm.pop_frame()?;
-        vm.current_frame_mut()?.gas_left += previous_frame.gas_left;
+        vm.current_frame_mut()?.gas_left += previous_frame.gas_left - previous_frame.stipend;
         if is_failure {
             vm.current_frame_mut()?.pc = previous_frame.exception_handler;
         } else {

--- a/src/op_handlers/ret.rs
+++ b/src/op_handlers/ret.rs
@@ -87,10 +87,15 @@ pub fn ret(
 
 pub fn inexplicit_panic(
     vm: &mut VMState,
+    should_use_gas: bool,
     state_storage: &mut StateStorage,
     transient_storage: &mut StateStorage,
 ) -> Result<bool, EraVmError> {
-    vm.decrease_gas(zkevm_opcode_defs::Opcode::Ret(RetOpcode::Panic).ergs_price())?;
+    if should_use_gas {
+        // we actually don't want to return here
+        // since this should call inexplicit panic again, but with the should_use_gas flag set to false.
+        let _ = vm.decrease_gas(zkevm_opcode_defs::Opcode::Ret(RetOpcode::Panic).ergs_price());
+    }
 
     vm.flag_eq = false;
     vm.flag_lt_of = true;

--- a/src/state.rs
+++ b/src/state.rs
@@ -78,6 +78,7 @@ impl VMState {
         let context = Context::new(
             program_code.clone(),
             u32::MAX - 0x80000000,
+            0,
             contract_address,
             contract_address,
             caller,
@@ -134,7 +135,8 @@ impl VMState {
     pub fn push_far_call_frame(
         &mut self,
         program_code: Vec<U256>,
-        gas_stipend: u32,
+        new_frame_gas: u32,
+        stipend: u32,
         code_address: Address,
         contract_address: Address,
         caller: Address,
@@ -149,7 +151,8 @@ impl VMState {
     ) -> Result<(), EraVmError> {
         let new_context = Context::new(
             program_code,
-            gas_stipend,
+            new_frame_gas,
+            stipend,
             contract_address,
             code_address,
             caller,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -147,6 +147,7 @@ impl EraVM {
             if self.state.decrease_gas(opcode.gas_cost).is_err() || can_execute.is_err() {
                 match inexplicit_panic(
                     &mut self.state,
+                    false,
                     &mut self.state_storage,
                     &mut self.transient_storage,
                 ) {
@@ -327,6 +328,7 @@ impl EraVM {
 
                     match inexplicit_panic(
                         &mut self.state,
+                        true,
                         &mut self.state_storage,
                         &mut self.transient_storage,
                     ) {


### PR DESCRIPTION
Various fixes related to how we were managing the gas consumption:
- `inexplicit_panic` and `panic_from_far_call` count as instructions and we should be decreasing the gas base cost for running them as well.
- When pushing a new `far_call` frame if the bytecode was for the evm interpreter, we were returning back not only the left gas but also the stipend one. 