### PR TITLE
fix: code-page reads must always succeed

### DIFF
--- a/src/address_operands.rs
+++ b/src/address_operands.rs
@@ -81,7 +81,7 @@ pub fn address_operands_read(
                 ImmMemHandlerFlags::UseCodePage => {
                     let (src0, src1) = reg_and_imm_read(vm, opcode);
 
-                    let res = vm.current_context()?.code_page.get(src0.value.low_u16());
+                    let res = vm.current_context()?.code_page.get(src0.value.low_u16() as usize);
                     (TaggedValue::new_raw_integer(res), src1)
                 }
             }

--- a/src/address_operands.rs
+++ b/src/address_operands.rs
@@ -81,7 +81,7 @@ pub fn address_operands_read(
                 ImmMemHandlerFlags::UseCodePage => {
                     let (src0, src1) = reg_and_imm_read(vm, opcode);
 
-                    let res = vm.current_context()?.code_page[src0.value.low_u16() as usize];
+                    let res = vm.current_context()?.code_page.get(src0.value.low_u16());
                     (TaggedValue::new_raw_integer(res), src1)
                 }
             }

--- a/src/address_operands.rs
+++ b/src/address_operands.rs
@@ -81,7 +81,10 @@ pub fn address_operands_read(
                 ImmMemHandlerFlags::UseCodePage => {
                     let (src0, src1) = reg_and_imm_read(vm, opcode);
 
-                    let res = vm.current_context()?.code_page.get(src0.value.low_u16() as usize);
+                    let res = vm
+                        .current_context()?
+                        .code_page
+                        .get(src0.value.low_u16() as usize);
                     (TaggedValue::new_raw_integer(res), src1)
                 }
             }

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -15,6 +15,18 @@ pub struct CallFrame {
 }
 
 #[derive(Debug, Clone)]
+pub struct CodePage(Vec<U256>);
+
+impl CodePage {
+    pub fn get(&self, idx: u16) -> U256 {
+        // NOTE: the spec mandates reads past the end of the program return any value that decodes
+        // as an `invalid` instruction. 0u256 fits the bill because its decoded variant is 0 which
+        // in turn is **the** invalid opcode.
+        self.0.get(idx as usize).cloned().unwrap_or_else(U256::zero)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Context {
     pub frame: CallFrame,
     pub near_call_frames: Vec<CallFrame>,
@@ -32,7 +44,7 @@ pub struct Context {
     pub aux_heap_id: u32,
     pub calldata_heap_id: u32,
     // Code memory is word addressable even though instructions are 64 bit wide.
-    pub code_page: Vec<U256>,
+    pub code_page: CodePage,
     pub is_static: bool,
 }
 
@@ -72,7 +84,7 @@ impl Context {
             heap_id,
             aux_heap_id,
             calldata_heap_id,
-            code_page: program_code,
+            code_page: CodePage(program_code),
             is_static,
         }
     }

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -18,7 +18,7 @@ pub struct CallFrame {
 pub struct CodePage(Vec<U256>);
 
 impl CodePage {
-    pub fn get(&self, idx: u16) -> U256 {
+    pub fn get(&self, idx: usize) -> U256 {
         // NOTE: the spec mandates reads past the end of the program return any value that decodes
         // as an `invalid` instruction. 0u256 fits the bill because its decoded variant is 0 which
         // in turn is **the** invalid opcode.

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -22,7 +22,7 @@ impl CodePage {
         // NOTE: the spec mandates reads past the end of the program return any value that decodes
         // as an `invalid` instruction. 0u256 fits the bill because its decoded variant is 0 which
         // in turn is **the** invalid opcode.
-        self.0.get(idx as usize).cloned().unwrap_or_else(U256::zero)
+        self.0.get(idx).cloned().unwrap_or_else(U256::zero)
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,7 +7,6 @@ use crate::eravm_error::{ContextError, EraVmError, HeapError, StackError};
 use crate::store::SnapShot;
 use crate::{
     opcode::Predicate,
-    utils::LowUnsigned,
     value::{FatPointer, TaggedValue},
     Opcode,
 };

--- a/src/state.rs
+++ b/src/state.rs
@@ -273,7 +273,7 @@ impl VMState {
         let raw_op = current_context
             .code_page
             // pc / 2
-            .get(pc.low_u16() >> 1);
+            .get(pc as usize >> 1);
         let opcode = match pc % 2 {
             1 => raw_op.low_u128(),
             _ => (raw_op >> 128).low_u128(),
@@ -283,7 +283,7 @@ impl VMState {
     pub fn get_opcode(&self) -> Result<Opcode, EraVmError> {
         let current_context = self.current_context()?;
         let pc = self.current_frame()?.pc;
-        let raw_opcode = current_context.code_page.get(pc.low_u16() / 4);
+        let raw_opcode = current_context.code_page.get(pc as usize / 4);
 
         let raw_op = match pc % 4 {
             3 => (raw_opcode & u64::MAX.into()).as_u64(),


### PR DESCRIPTION
From the spec:
> Code pages
> A code page contains 2^16 instructions. They are not writable.
> On genesis, code pages are filled as follows:
> The contract code is places starting from the address 0.
> The rest is filled with a value guaranteed to decode as invalid
> instruction.

Our code before this fix panics when running the benchmarks due to this
discrepancy.

The applied fix creates a newtype for code pages that wraps the
`Vec<U256>` and returns `U256::zero()` when reading out of bounds, which
decodes to an invalid instruction, matching the spec and fixing the
`panic`.

EDIT: the test encoding exceeds the 2^16 range, so I removed that restriction.

Fixes #189
