### PR TITLE
Zksync-era basic tests integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "era-compiler-tester"]
 	path = era-compiler-tester
 	url = https://github.com/lambdaclass/era-compiler-tester.git
+	branch = zksync-era-tests

--- a/src/call_frame.rs
+++ b/src/call_frame.rs
@@ -4,7 +4,7 @@ use zkevm_opcode_defs::ethereum_types::Address;
 
 use crate::{state::Stack, store::SnapShot, utils::is_kernel};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CallFrame {
     pub pc: u64,
     pub transient_storage_snapshot: SnapShot,
@@ -14,7 +14,7 @@ pub struct CallFrame {
     pub storage_snapshot: SnapShot,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Context {
     pub frame: CallFrame,
     pub near_call_frames: Vec<CallFrame>,

--- a/src/heaps.rs
+++ b/src/heaps.rs
@@ -2,7 +2,7 @@ use zkevm_opcode_defs::system_params::NEW_FRAME_MEMORY_STIPEND;
 
 use crate::{eravm_error::HeapError, state::Heap};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Heaps {
     heaps: Vec<Heap>,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
 use std::num::Saturating;
+use std::u32;
 
 use crate::call_frame::{CallFrame, Context};
 use crate::heaps::Heaps;
@@ -18,16 +19,16 @@ pub const CALLDATA_HEAP: u32 = 1;
 pub const FIRST_HEAP: u32 = 2;
 pub const FIRST_AUX_HEAP: u32 = 3;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Stack {
     pub stack: Vec<TaggedValue>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Heap {
     heap: Vec<u8>,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct VMState {
     // The first register, r0, is actually always zero and not really used.
     // Writing to it does nothing.
@@ -478,7 +479,7 @@ impl Heap {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Event {
     pub key: U256,
     pub value: U256,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,4 @@
 use std::num::Saturating;
-use std::u32;
 
 use crate::call_frame::{CallFrame, Context};
 use crate::heaps::Heaps;
@@ -51,8 +50,6 @@ pub struct VMState {
     pub use_hooks: bool,
 }
 
-// Totally arbitrary, probably we will have to change it later.
-pub const DEFAULT_INITIAL_GAS: u32 = 1 << 16;
 impl VMState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -65,6 +62,7 @@ impl VMState {
         evm_interpreter_code_hash: [u8; 32],
         hook_address: u32,
         use_hooks: bool,
+        initial_gas: u32,
     ) -> Self {
         let mut registers = [TaggedValue::default(); 15];
         let calldata_ptr = FatPointer {
@@ -78,7 +76,7 @@ impl VMState {
 
         let context = Context::new(
             program_code.clone(),
-            u32::MAX - 0x80000000,
+            initial_gas,
             contract_address,
             contract_address,
             caller,

--- a/src/store.rs
+++ b/src/store.rs
@@ -125,7 +125,7 @@ impl StateStorage {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct SnapShot {
     pub storage_changes: HashMap<StorageKey, U256>,
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -56,7 +56,7 @@ impl ContractStorage for ContractStorageMemory {
 pub struct StateStorage {
     pub storage_changes: HashMap<StorageKey, U256>,
     pub initial_storage: Rc<RefCell<dyn InitialStorage>>,
-    l2_to_l1_logs: Vec<L2ToL1Log>,
+    pub l2_to_l1_logs: Vec<L2ToL1Log>,
 }
 
 impl Default for StateStorage {

--- a/src/store.rs
+++ b/src/store.rs
@@ -40,6 +40,7 @@ impl InitialStorage for InitialStorageMemory {
 
 pub trait ContractStorage: Debug {
     fn decommit(&self, hash: U256) -> Result<Option<Vec<U256>>, StorageError>;
+    fn hash_map(&self) -> Result<HashMap<U256, Vec<U256>>, StorageError>;
 }
 #[derive(Debug)]
 pub struct ContractStorageMemory {
@@ -49,6 +50,10 @@ pub struct ContractStorageMemory {
 impl ContractStorage for ContractStorageMemory {
     fn decommit(&self, hash: U256) -> Result<Option<Vec<U256>>, StorageError> {
         Ok(self.contract_storage.get(&hash).cloned())
+    }
+
+    fn hash_map(&self) -> Result<HashMap<U256, Vec<U256>>, StorageError> {
+        Ok(self.contract_storage.clone())
     }
 }
 

--- a/src/tracers/last_state_saver_tracer.rs
+++ b/src/tracers/last_state_saver_tracer.rs
@@ -25,6 +25,7 @@ impl LastStateSaverTracer {
                 Default::default(),
                 0,
                 false,
+                0,
             ),
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,7 +2,7 @@ use u256::U256;
 
 /// In the zkEVM, all data in the stack and on registers is tagged to determine
 /// whether they are a pointer or not.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TaggedValue {
     pub value: U256,
     pub is_pointer: bool,


### PR DESCRIPTION
This pr adds necessary changes in the vm structure to start testing it on zksync-era. For testing the vm on zksync-era, see this [pr](https://github.com/lambdaclass/zksync-era/pull/229/files).