### PR TITLE
Implement statistics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod opcode;
 pub mod output;
 mod precompiles;
 mod ptr_operator;
+pub mod statistics;
 pub mod store;
 pub mod tracers;
 pub mod utils;

--- a/src/op_handlers/far_call.rs
+++ b/src/op_handlers/far_call.rs
@@ -363,20 +363,20 @@ pub fn far_call(
 }
 
 pub struct FarCallABI {
-    pub gas_to_pass: u32,
-    pub shard_id: u8,
+    pub _gas_to_pass: u32,
+    pub _shard_id: u8,
     pub is_constructor_call: bool,
     pub is_system_call: bool,
 }
 
 pub fn get_far_call_arguments(abi: U256) -> FarCallABI {
-    let gas_to_pass = abi.0[3] as u32;
+    let _gas_to_pass = abi.0[3] as u32;
     let settings = (abi.0[3] >> 32) as u32;
-    let [_, shard_id, constructor_call_byte, system_call_byte] = settings.to_le_bytes();
+    let [_, _shard_id, constructor_call_byte, system_call_byte] = settings.to_le_bytes();
 
     FarCallABI {
-        gas_to_pass,
-        shard_id,
+        _gas_to_pass,
+        _shard_id,
         is_constructor_call: constructor_call_byte != 0,
         is_system_call: system_call_byte != 0,
     }

--- a/src/op_handlers/opcode_decommit.rs
+++ b/src/op_handlers/opcode_decommit.rs
@@ -5,6 +5,7 @@ use crate::{
     eravm_error::{EraVmError, HeapError},
     execution::Execution,
     state::VMState,
+    statistics::{VmStatistics, STORAGE_READ_STORAGE_APPLICATION_CYCLES},
     value::{FatPointer, TaggedValue},
     Opcode,
 };
@@ -13,6 +14,7 @@ pub fn opcode_decommit(
     vm: &mut Execution,
     opcode: &Opcode,
     state: &mut VMState,
+    statistics: &mut VmStatistics,
 ) -> Result<(), EraVmError> {
     let (src0, src1) = address_operands_read(vm, opcode)?;
 
@@ -36,7 +38,9 @@ pub fn opcode_decommit(
     if was_decommited {
         // refund it
         vm.increase_gas(extra_cost)?;
-    };
+    } else {
+        statistics.storage_application_cycles += STORAGE_READ_STORAGE_APPLICATION_CYCLES;
+    }
 
     let code = code.ok_or(EraVmError::DecommitFailed)?;
 

--- a/src/op_handlers/precompile_call.rs
+++ b/src/op_handlers/precompile_call.rs
@@ -15,6 +15,7 @@ use crate::{
         secp256r1_verify::secp256r1_verify_function, sha256::sha256_rounds_function,
     },
     state::VMState,
+    statistics::VmStatistics,
     value::TaggedValue,
     Opcode,
 };
@@ -23,6 +24,7 @@ pub fn precompile_call(
     vm: &mut Execution,
     opcode: &Opcode,
     state: &mut VMState,
+    statistics: &mut VmStatistics,
 ) -> Result<(), EraVmError> {
     let (src0, src1) = address_operands_read(vm, opcode)?;
     let aux_data = PrecompileAuxData::from_u256(src1.value);
@@ -45,16 +47,16 @@ pub fn precompile_call(
 
     match address_low {
         KECCAK256_ROUND_FUNCTION_PRECOMPILE_ADDRESS => {
-            keccak256_rounds_function(abi_key, heaps)?;
+            statistics.keccak256_cycles += keccak256_rounds_function(abi_key, heaps)?;
         }
         SHA256_ROUND_FUNCTION_PRECOMPILE_ADDRESS => {
-            sha256_rounds_function(abi_key, heaps)?;
+            statistics.sha256_cycles += sha256_rounds_function(abi_key, heaps)?;
         }
         ECRECOVER_INNER_FUNCTION_PRECOMPILE_ADDRESS => {
-            ecrecover_function(abi_key, heaps)?;
+            statistics.ecrecover_cycles += ecrecover_function(abi_key, heaps)?;
         }
         SECP256R1_VERIFY_PRECOMPILE_ADDRESS => {
-            secp256r1_verify_function(abi_key, heaps)?;
+            statistics.secp255r1_verify_cycles += secp256r1_verify_function(abi_key, heaps)?;
         }
         _ => {
             // A precompile call may be used just to burn gas

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use zkevm_opcode_defs::Opcode as Variant;
+pub use zkevm_opcode_defs::Opcode as Variant;
 use zkevm_opcode_defs::OpcodeVariant;
 use zkevm_opcode_defs::Operand;
 use zkevm_opcode_defs::CONDITIONAL_BITS_SHIFT;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,3 +1,5 @@
+use crate::eravm_error::EraVmError;
+use crate::eravm_error::OpcodeError;
 use lazy_static::lazy_static;
 pub use zkevm_opcode_defs::Opcode as Variant;
 use zkevm_opcode_defs::OpcodeVariant;
@@ -6,9 +8,7 @@ use zkevm_opcode_defs::CONDITIONAL_BITS_SHIFT;
 use zkevm_opcode_defs::DST_REGS_SHIFT;
 use zkevm_opcode_defs::OPCODES_TABLE_WIDTH;
 use zkevm_opcode_defs::SRC_REGS_SHIFT;
-
-use crate::eravm_error::EraVmError;
-use crate::eravm_error::OpcodeError;
+pub use zkevm_opcode_defs::{LogOpcode, RetOpcode, UMAOpcode};
 
 #[derive(Debug, Clone)]
 pub enum Predicate {

--- a/src/precompiles/ecrecover.rs
+++ b/src/precompiles/ecrecover.rs
@@ -18,11 +18,13 @@ pub use zkevm_opcode_defs::sha3::Keccak256;
 
 use super::*;
 
+const NUM_ROUNDS: usize = 1;
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ECRecoverPrecompile;
 
 impl Precompile for ECRecoverPrecompile {
-    fn execute_precompile(&mut self, query: U256, heaps: &mut Heaps) -> Result<(), EraVmError> {
+    fn execute_precompile(&mut self, query: U256, heaps: &mut Heaps) -> Result<usize, EraVmError> {
         let precompile_call_params = query;
         let params = precompile_abi_in_log(precompile_call_params);
         let addr = |offset: u32| (params.output_memory_offset + offset) * 32;
@@ -65,7 +67,7 @@ impl Precompile for ECRecoverPrecompile {
         write_heap.store(addr(0), marker);
         write_heap.store(addr(1), result);
 
-        Ok(())
+        Ok(NUM_ROUNDS)
     }
 }
 
@@ -152,6 +154,6 @@ fn get_address_from_pk(pk: VerifyingKey) -> Result<[u8; 32], EraVmError> {
     Ok(address)
 }
 
-pub fn ecrecover_function(abi: U256, heaps: &mut Heaps) -> Result<(), EraVmError> {
+pub fn ecrecover_function(abi: U256, heaps: &mut Heaps) -> Result<usize, EraVmError> {
     ECRecoverPrecompile.execute_precompile(abi, heaps)
 }

--- a/src/precompiles/ecrecover.rs
+++ b/src/precompiles/ecrecover.rs
@@ -18,8 +18,6 @@ pub use zkevm_opcode_defs::sha3::Keccak256;
 
 use super::*;
 
-const NUM_ROUNDS: usize = 1;
-
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ECRecoverPrecompile;
 
@@ -67,7 +65,7 @@ impl Precompile for ECRecoverPrecompile {
         write_heap.store(addr(0), marker);
         write_heap.store(addr(1), result);
 
-        Ok(NUM_ROUNDS)
+        Ok(DEFAULT_NUM_ROUNDS)
     }
 }
 

--- a/src/precompiles/keccak256.rs
+++ b/src/precompiles/keccak256.rs
@@ -70,7 +70,11 @@ fn hash_as_bytes32(hash: [u64; 25]) -> [u8; 32] {
 struct Keccak256Precompile;
 
 impl Precompile for Keccak256Precompile {
-    fn execute_precompile(&mut self, abi_key: U256, heaps: &mut Heaps) -> Result<(), EraVmError> {
+    fn execute_precompile(
+        &mut self,
+        abi_key: U256,
+        heaps: &mut Heaps,
+    ) -> Result<usize, EraVmError> {
         let mut full_round_padding = [0u8; KECCAK_RATE_BYTES];
         full_round_padding[0] = 0x01;
         full_round_padding[KECCAK_RATE_BYTES - 1] = 0x80;
@@ -148,10 +152,10 @@ impl Precompile for Keccak256Precompile {
             .try_get_mut(params.memory_page_to_write)?
             .store(params.output_memory_offset * 32, hash);
 
-        Ok(())
+        Ok(num_rounds)
     }
 }
 
-pub fn keccak256_rounds_function(abi_key: U256, heaps: &mut Heaps) -> Result<(), EraVmError> {
+pub fn keccak256_rounds_function(abi_key: U256, heaps: &mut Heaps) -> Result<usize, EraVmError> {
     Keccak256Precompile.execute_precompile(abi_key, heaps)
 }

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -9,7 +9,8 @@ pub mod secp256r1_verify;
 pub mod sha256;
 
 pub trait Precompile: std::fmt::Debug {
-    fn execute_precompile(&mut self, abi_key: U256, heaps: &mut Heaps) -> Result<(), EraVmError>;
+    fn execute_precompile(&mut self, abi_key: U256, heaps: &mut Heaps)
+        -> Result<usize, EraVmError>;
 }
 
 pub struct PrecompileCallABI {

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -8,6 +8,8 @@ pub mod keccak256;
 pub mod secp256r1_verify;
 pub mod sha256;
 
+const DEFAULT_NUM_ROUNDS: usize = 1;
+
 pub trait Precompile: std::fmt::Debug {
     fn execute_precompile(&mut self, abi_key: U256, heaps: &mut Heaps)
         -> Result<usize, EraVmError>;

--- a/src/precompiles/secp256r1_verify.rs
+++ b/src/precompiles/secp256r1_verify.rs
@@ -7,11 +7,13 @@ use zkevm_opcode_defs::p256::{
     AffinePoint, EncodedPoint,
 };
 
+const NUM_ROUNDS: usize = 1;
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Secp256r1VerifyPrecompile;
 
 impl Precompile for Secp256r1VerifyPrecompile {
-    fn execute_precompile(&mut self, query: U256, heaps: &mut Heaps) -> Result<(), EraVmError> {
+    fn execute_precompile(&mut self, query: U256, heaps: &mut Heaps) -> Result<usize, EraVmError> {
         let precompile_call_params = query;
         let params = precompile_abi_in_log(precompile_call_params);
         let addr = |offset: u32| (params.output_memory_offset + offset) * 32;
@@ -52,7 +54,7 @@ impl Precompile for Secp256r1VerifyPrecompile {
         write_heap.store(addr(0), marker);
         write_heap.store(addr(1), result);
 
-        Ok(())
+        Ok(NUM_ROUNDS)
     }
 }
 
@@ -90,6 +92,6 @@ pub fn secp256r1_verify_inner(
 }
 
 // Verifies an ECDSA signature against a message digest using a given public key.
-pub fn secp256r1_verify_function(abi_key: U256, heaps: &mut Heaps) -> Result<(), EraVmError> {
+pub fn secp256r1_verify_function(abi_key: U256, heaps: &mut Heaps) -> Result<usize, EraVmError> {
     Secp256r1VerifyPrecompile.execute_precompile(abi_key, heaps)
 }

--- a/src/precompiles/secp256r1_verify.rs
+++ b/src/precompiles/secp256r1_verify.rs
@@ -1,4 +1,4 @@
-use super::{precompile_abi_in_log, Precompile};
+use super::{precompile_abi_in_log, Precompile, DEFAULT_NUM_ROUNDS};
 use crate::{eravm_error::EraVmError, heaps::Heaps};
 use u256::U256;
 use zkevm_opcode_defs::p256::{
@@ -6,8 +6,6 @@ use zkevm_opcode_defs::p256::{
     elliptic_curve::{generic_array::GenericArray, sec1::FromEncodedPoint},
     AffinePoint, EncodedPoint,
 };
-
-const NUM_ROUNDS: usize = 1;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Secp256r1VerifyPrecompile;
@@ -54,7 +52,7 @@ impl Precompile for Secp256r1VerifyPrecompile {
         write_heap.store(addr(0), marker);
         write_heap.store(addr(1), result);
 
-        Ok(NUM_ROUNDS)
+        Ok(DEFAULT_NUM_ROUNDS)
     }
 }
 

--- a/src/precompiles/sha256.rs
+++ b/src/precompiles/sha256.rs
@@ -19,7 +19,11 @@ fn hash_as_bytes32(hash: [u32; 8]) -> [u8; 32] {
 pub struct Sha256Precompile;
 
 impl Precompile for Sha256Precompile {
-    fn execute_precompile(&mut self, abi_key: U256, heaps: &mut Heaps) -> Result<(), EraVmError> {
+    fn execute_precompile(
+        &mut self,
+        abi_key: U256,
+        heaps: &mut Heaps,
+    ) -> Result<usize, EraVmError> {
         let params = precompile_abi_in_log(abi_key);
         let num_rounds = params.precompile_interpreted_data as usize;
         let mut read_addr = params.input_memory_offset;
@@ -44,10 +48,10 @@ impl Precompile for Sha256Precompile {
             .try_get_mut(params.memory_page_to_write)?
             .store(write_addr, hash);
 
-        Ok(())
+        Ok(num_rounds)
     }
 }
 
-pub fn sha256_rounds_function(abi_key: U256, heaps: &mut Heaps) -> Result<(), EraVmError> {
+pub fn sha256_rounds_function(abi_key: U256, heaps: &mut Heaps) -> Result<usize, EraVmError> {
     Sha256Precompile.execute_precompile(abi_key, heaps)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -131,6 +131,14 @@ impl VMState {
         self.pubdata.value += to_add;
     }
 
+    pub fn read_storage_slots(&self) -> &HashSet<StorageKey> {
+        &self.read_storage_slots.map
+    }
+
+    pub fn written_storage_slots(&self) -> &HashSet<StorageKey> {
+        &self.written_storage_slots.map
+    }
+
     pub fn storage_read(&mut self, key: StorageKey) -> (U256, u32) {
         let value = self.storage_read_inner(&key).unwrap_or_default();
 
@@ -188,6 +196,7 @@ impl VMState {
         let mut storage = self.storage.borrow_mut();
 
         if storage.is_free_storage_slot(&key) {
+            self.written_storage_slots.map.insert(key);
             let refund = WARM_WRITE_REFUND;
             self.refunds.entries.push(refund);
             self.pubdata_costs.entries.push(0);

--- a/src/state.rs
+++ b/src/state.rs
@@ -135,6 +135,8 @@ impl VMState {
         &self.written_storage_slots.map
     }
 
+    // reads shouldn't be mutable, we should consider change it to a non-mutable reference
+    // though that would require a refactor in the integration with the operator
     pub fn storage_read(&mut self, key: StorageKey) -> (U256, u32) {
         let value = self
             .storage_read_inner(&key)

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,0 +1,20 @@
+use u256::U256;
+
+pub const STORAGE_READ_STORAGE_APPLICATION_CYCLES: usize = 1;
+pub const STORAGE_WRITE_STORAGE_APPLICATION_CYCLES: usize = 2;
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct VmStatistics {
+    pub keccak256_cycles: usize,
+    pub ecrecover_cycles: usize,
+    pub sha256_cycles: usize,
+    pub secp255r1_verify_cycles: usize,
+    pub code_decommitter_cycles: usize,
+    pub storage_application_cycles: usize,
+}
+
+impl VmStatistics {
+    pub fn decommiter_cycle_from_decommit(&mut self, code_page: &[U256]) {
+        self.code_decommitter_cycles += (code_page.len() + 1) / 2
+    }
+}

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -5,6 +5,7 @@ pub const STORAGE_WRITE_STORAGE_APPLICATION_CYCLES: usize = 2;
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct VmStatistics {
+    pub monotonic_counter: u32,
     pub keccak256_cycles: usize,
     pub ecrecover_cycles: usize,
     pub sha256_cycles: usize,

--- a/src/tracers/no_tracer.rs
+++ b/src/tracers/no_tracer.rs
@@ -1,6 +1,4 @@
 use super::tracer::Tracer;
-use crate::state::VMState;
-use crate::{execution::Execution, Opcode};
 
 #[derive(Default)]
 pub struct NoTracer {}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -345,7 +345,7 @@ impl EraVM {
             } else {
                 self.execution.current_frame_mut()?.pc += 1;
             }
-
+            self.statistics.monotonic_counter += 1;
             tracer.after_execution(&opcode, &mut self.execution, &mut self.state);
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -43,6 +43,7 @@ use crate::op_handlers::sub::sub;
 use crate::op_handlers::unimplemented::unimplemented;
 use crate::op_handlers::xor::xor;
 use crate::state::{FullStateSnapshot, VMState};
+use crate::statistics::VmStatistics;
 use crate::store::Storage;
 use crate::tracers::no_tracer::NoTracer;
 use crate::value::{FatPointer, TaggedValue};
@@ -60,11 +61,13 @@ pub enum ExecutionOutput {
 #[derive(Debug, Clone)]
 pub struct EraVM {
     pub state: VMState,
+    pub statistics: VmStatistics,
     pub execution: Execution,
 }
 
 pub struct VmSnapshot {
     execution: ExecutionSnapshot,
+    statistics: VmStatistics,
     state: FullStateSnapshot,
 }
 
@@ -77,6 +80,7 @@ impl EraVM {
     pub fn new(execution: Execution, storage: Rc<RefCell<dyn Storage>>) -> Self {
         Self {
             state: VMState::new(storage),
+            statistics: VmStatistics::default(),
             execution,
         }
     }
@@ -112,12 +116,14 @@ impl EraVM {
         VmSnapshot {
             execution: self.execution.snapshot(),
             state: self.state.full_state_snapshot(),
+            statistics: self.statistics.clone(),
         }
     }
 
     pub fn rollback(&mut self, snapshot: VmSnapshot) {
         self.execution.rollback(snapshot.execution);
         self.state.external_rollback(snapshot.state);
+        self.statistics = snapshot.statistics;
     }
 
     /// Run a vm program from the given path using a custom state.
@@ -219,22 +225,34 @@ impl EraVM {
                     },
                     Variant::NearCall(_) => near_call(&mut self.execution, &opcode, &self.state),
                     Variant::Log(log_variant) => match log_variant {
-                        LogOpcode::StorageRead => {
-                            storage_read(&mut self.execution, &opcode, &mut self.state)
-                        }
-                        LogOpcode::StorageWrite => {
-                            storage_write(&mut self.execution, &opcode, &mut self.state)
-                        }
+                        LogOpcode::StorageRead => storage_read(
+                            &mut self.execution,
+                            &opcode,
+                            &mut self.state,
+                            &mut self.statistics,
+                        ),
+                        LogOpcode::StorageWrite => storage_write(
+                            &mut self.execution,
+                            &opcode,
+                            &mut self.state,
+                            &mut self.statistics,
+                        ),
                         LogOpcode::ToL1Message => {
                             add_l2_to_l1_message(&mut self.execution, &opcode, &mut self.state)
                         }
-                        LogOpcode::PrecompileCall => {
-                            precompile_call(&mut self.execution, &opcode, &mut self.state)
-                        }
+                        LogOpcode::PrecompileCall => precompile_call(
+                            &mut self.execution,
+                            &opcode,
+                            &mut self.state,
+                            &mut self.statistics,
+                        ),
                         LogOpcode::Event => event(&mut self.execution, &opcode, &mut self.state),
-                        LogOpcode::Decommit => {
-                            opcode_decommit(&mut self.execution, &opcode, &mut self.state)
-                        }
+                        LogOpcode::Decommit => opcode_decommit(
+                            &mut self.execution,
+                            &opcode,
+                            &mut self.state,
+                            &mut self.statistics,
+                        ),
                         LogOpcode::TransientStorageRead => {
                             transient_storage_read(&mut self.execution, &opcode, &mut self.state)
                         }
@@ -248,6 +266,7 @@ impl EraVM {
                             &opcode,
                             &far_call_variant,
                             &mut self.state,
+                            &mut self.statistics,
                         );
                         if res.is_err() {
                             panic_from_far_call(&mut self.execution, &opcode)?;


### PR DESCRIPTION
This pr adds vm statistics to be used in the zksync-era integration, that includes:
- Collecting precompiles round counts
- Collect storages reads and writes cycles.
- Collect vm number of instructions run (or, as they call it, monotonic counter)
- Collect decommit cycles

This implementation is supported by the [circuits tracer tests](https://github.com/lambdaclass/zksync-era/pull/243/commits/8abf5c725da6050fdcbfa6eabe0fc7a2856046a5) in the zksync-era integration.