### PR TITLE
Optimization: Modify `Heap` read and write related functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,10 +552,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Zksync-era dependencies
+      - name: Zksync-era + perf dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: clang clang-tools build-essential librocksdb-dev
+          packages: clang clang-tools build-essential librocksdb-dev  linux-tools-common linux-tools-generic linux-perf
           version: 1.0
 
       - name: Setup nodejs + yarn
@@ -585,24 +585,30 @@ jobs:
           chmod +x solc
           sudo cp solc /usr/bin/solc
 
-      - name: Build benchmark contracts
-        working-directory: ${{ github.workspace }}
-        run: make bench-setup
 
-      - name: Fetch toolchain version from zksync-era
+      - name: Fetch toolchain version from zksync-era + set zksync home
         run: |
           cd ${{ github.workspace }}/zksync-era
           echo "ERA_TOOLCHAIN=$(head ./rust-toolchain)" >> $GITHUB_ENV
+          echo "ZKSYNC_HOME=${{ github.workspace }}/zksync-era" >> $GITHUB_ENV
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: ${{ env.ERA_TOOLCHAIN }}
 
+      - name: Build benchmark contracts
+        working-directory: ${{ github.workspace }}
+        run: make bench-setup
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             ${{ github.workspace }}/zksync-era/core/tests/vm-benchmark
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: flamegraph
 
       - name: Check zksync-era benchmarks & era_vm build correctly
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean lint test deps submodules bench era-test build-bench-contracts %.sol
+.PHONY: clean lint test deps submodules bench flamegraph era-test build-bench-contracts %.sol
 .SILENT: %.sol
 
 LLVM_PATH?=$(shell pwd)/era-compiler-tester/target-llvm/target-final/
@@ -9,7 +9,7 @@ ZKSYNC_SYS_CONTRACTS=$(ZKSYNC_ROOT)/contracts/system-contracts/artifacts-zk
 ZKSYNC_BOOTLOADER_CONTRACT=$(ZKSYNC_ROOT)/contracts/system-contracts/bootloader/build/artifacts
 ZKSYNC_BENCH_TEST_DATA=$(ZKSYNC_ROOT)/etc/contracts-test-data/artifacts-zk
 ZKSYNC_BENCH_CONTRACTS=$(ZKSYNC_ROOT)/core/tests/vm-benchmark/deployment_benchmarks
-ZKSYNC_BENCH_SOURCES=$(ZKSYNC_ROOT)/core/tests/vm-benchmark/deployment_benchmarks_sources
+BENCH_SOURCES=$(shell realpath ./deployment_benchmarks_sources)
 
 
 clean:
@@ -71,7 +71,7 @@ $(ZKSYNC_BENCH_TEST_DATA):
 #     a file insie the contract benchmarks folder.
 %.sol:
 	echo "Building benchmark contract: $@"
-	cd $(ZKSYNC_BENCH_SOURCES) && \
+	cd $(BENCH_SOURCES) && \
 	zksolc --bin $@ | grep -oE '0x[0-9a-fA-F]+' > $(ZKSYNC_BENCH_CONTRACTS)/$(basename $@)
 
 build_bench_contracts: fibonacci_rec.sol send.sol
@@ -83,6 +83,9 @@ bench-setup: submodules build_bench_contracts $(ZKSYNC_BENCH_TEST_DATA) $(ZKSYNC
 
 bench:
 	cd $(ZKSYNC_ROOT) && cargo bench --bench criterion "$(lambda|fast_vm|legacy)/(fibonacci|send)"
+
+check-flamegraph:
+	cd $(ZKSYNC_ROOT) && CARGO_PROFILE_BENCH_DEBUG=2 cargo flamegraph --root --bench criterion -- --bench --profile-time 5 "$lambda/fibonacci_rec^"
 
 bench-base:
 	cd $(ZKSYNC_ROOT) && cargo bench --bench criterion -- --save-baseline bench_base lambda 1>bench-compare.txt

--- a/bench_results.py
+++ b/bench_results.py
@@ -1,0 +1,55 @@
+import re
+import sys
+
+def convert_to_ms(value, unit):
+    if unit == 'µs':
+        return value / 1000
+    elif unit == 'ms':
+        return value
+    elif unit == 's':
+        return value * 1000
+    else:
+        raise ValueError(f"Unknown time unit: {unit}")
+
+def parse_benchmark_file(file_path):
+    machines = {}
+    pattern = r'(\w+)/\w+\s+time:\s+\[\d+(?:\.\d+)?\s(\w+)\s(\d+(?:\.\d+)?)\s(\w+)\s\d+(?:\.\d+)?\s(\w+)\]'
+
+    with open(file_path, 'r') as file:
+        content = file.read()
+        # Clean the file content
+        cleaned_content = re.sub(r'\n(\s+)time:', ' time:', content)
+        for line in cleaned_content.split('\n'):
+            match = re.match(pattern, line)
+            if match:
+                machine, lower_unit, mid_time, mid_unit, upper_unit = match.groups()
+                # Convert mid_time to milliseconds
+                mid_time_ms = convert_to_ms(float(mid_time), mid_unit)
+                machines[machine] = machines.get(machine, 0) + mid_time_ms
+
+    return machines
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: results.py <path-to-file>")
+        return
+    file_path = sys.argv[1]
+    results = parse_benchmark_file(file_path)
+
+    for machine, total_time in results.items():
+        print(f"Total {machine} time: {total_time:.3f} ms")
+
+    if not "lambda" in results:
+        return
+
+    print("")
+
+    if "legacy" in results:
+        lambda_vs_legacy = round(results["lambda"] / results["legacy"], 1)
+        print(f"lambda_vm took x{lambda_vs_legacy} more than legacy_vm")
+    if "fast" in results:
+        lambda_vs_fast = round(results["lambda"] / results["fast"], 1)
+        print(f"lambda_vm took x{lambda_vs_fast} more than fast_vm")
+
+if __name__ == "__main__":
+    main()

--- a/deployment_benchmarks_sources/factorial_it.sol
+++ b/deployment_benchmarks_sources/factorial_it.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.8.0;
+
+contract benchmark {
+    uint256 value;
+    constructor() {
+      value = fac(57);
+    }
+
+    function get_calculation() public view returns (uint256) {
+        return value;
+    }
+
+    function fac(uint n) internal pure returns(uint256) { 
+        uint256 r = 1;
+        for (uint256 k = 2; k <= n; k++) {
+            r = k * r;
+        }
+
+        return r;
+    }
+}
+

--- a/deployment_benchmarks_sources/factorial_rec.sol
+++ b/deployment_benchmarks_sources/factorial_rec.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.8.0;
+
+contract benchmark {
+    uint256 value;
+    constructor() {
+      value = fac(57);
+    }
+
+    function get_calculation() public view returns (uint256) {
+        return value;
+    }
+
+    function fac(uint256 n) internal returns (uint256) {
+        if (n <= 1) {
+            return 1;
+        }
+        return n * fac(n - 1);
+    }
+}
+

--- a/deployment_benchmarks_sources/fibonacci_it.sol
+++ b/deployment_benchmarks_sources/fibonacci_it.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.8.0;
+
+contract benchmark {
+    uint256 value;
+    constructor() {
+      value = fib(370);
+    }
+
+    function get_calculation() public view returns (uint256) {
+        return value;
+    }
+
+    function fib(uint n) internal pure returns(uint b) { 
+        if (n == 0) {
+            return 0;   
+        }
+        uint a = 1;
+        b = 1;
+        for (uint i = 2; i < n; i++) {
+            uint c = a + b;
+            a = b;
+            b = c;
+        }
+        return b;
+    }
+}

--- a/deployment_benchmarks_sources/fibonacci_rec.sol
+++ b/deployment_benchmarks_sources/fibonacci_rec.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.8.0;
+
+contract benchmark {
+    uint256 value;
+    constructor() {
+      value = fib(25);
+    }
+
+    function get_calculation() public view returns (uint256) {
+        return value;
+    }
+
+    function fib(uint256 n) internal returns (uint256) {
+        if (n <= 1) {
+            return n;
+        }
+        return fib(n - 1) + fib(n - 2);
+    }
+}

--- a/deployment_benchmarks_sources/heap_read_write.sol
+++ b/deployment_benchmarks_sources/heap_read_write.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.8.0;
+
+contract HeapBenchmark {
+    constructor() {
+        uint256 v1 = 0;
+        uint256 v2 = 0;
+        uint256 n = 16000;
+        uint256[] memory array = new uint256[](1);
+
+        assembly {
+            mstore(add(array, sub(n, 1)), 4242)
+
+            let j := 0
+            for {} lt(j, n) {} {
+                v1 := mload(add(array, mod(mul(j, j), n)))
+                v2 := mload(add(array, j))
+                mstore(add(array, j), add(add(v1, v2), 42))
+                j := add(j, 1) 
+                if gt(j, sub(n, 1)) {
+                    j := 0
+                }
+            }
+        }
+    }
+}

--- a/deployment_benchmarks_sources/send.sol
+++ b/deployment_benchmarks_sources/send.sol
@@ -1,0 +1,8 @@
+pragma solidity >=0.8.20;
+
+contract Send {
+    constructor() {
+        address payable self = payable(msg.sender);
+        self.call{value: 100};
+    }
+}

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -3,7 +3,7 @@ use std::num::Saturating;
 use crate::call_frame::{CallFrame, Context};
 use crate::heaps::Heaps;
 
-use crate::eravm_error::{ContextError, EraVmError, StackError};
+use crate::eravm_error::{ContextError, EraVmError, HeapError, StackError};
 use crate::state::StateSnapshot;
 use crate::{
     opcode::Predicate,
@@ -497,10 +497,10 @@ impl Heap {
         result
     }
 
-    pub fn read_unaligned_from_pointer(&self, pointer: &FatPointer) -> &[u8] {
+    pub fn read_unaligned_from_pointer(&self, pointer: &FatPointer) -> Result<Vec<u8>, HeapError> {
         let start = (pointer.start + pointer.offset) as usize;
         let finish = (start + pointer.len as usize).min(self.heap.len());
-        &self.heap[start..finish]
+        Ok(self.heap[start..finish].into())
     }
 
     pub fn len(&self) -> usize {

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -3,7 +3,7 @@ use std::num::Saturating;
 use crate::call_frame::{CallFrame, Context};
 use crate::heaps::Heaps;
 
-use crate::eravm_error::{ContextError, EraVmError, HeapError, StackError};
+use crate::eravm_error::{ContextError, EraVmError, StackError};
 use crate::state::StateSnapshot;
 use crate::{
     opcode::Predicate,
@@ -497,10 +497,10 @@ impl Heap {
         result
     }
 
-    pub fn read_unaligned_from_pointer(&self, pointer: &FatPointer) -> Result<Vec<u8>, HeapError> {
+    pub fn read_unaligned_from_pointer(&self, pointer: &FatPointer) -> &[u8] {
         let start = (pointer.start + pointer.offset) as usize;
         let finish = (start + pointer.len as usize).min(self.heap.len());
-        Ok(self.heap[start..finish].into())
+        &self.heap[start..finish]
     }
 
     pub fn len(&self) -> usize {

--- a/src/tracers/blob_saver_tracer.rs
+++ b/src/tracers/blob_saver_tracer.rs
@@ -77,7 +77,7 @@ impl Tracer for BlobSaverTracer {
             .heaps
             .get(ptr.page)
             .ok_or(HeapError::ReadOutOfBounds)?
-            .read_unaligned_from_pointer(&ptr);
+            .read_unaligned_from_pointer(&ptr)?;
 
         if data.len() < 64 {
             // Not interested

--- a/src/tracers/blob_saver_tracer.rs
+++ b/src/tracers/blob_saver_tracer.rs
@@ -77,7 +77,7 @@ impl Tracer for BlobSaverTracer {
             .heaps
             .get(ptr.page)
             .ok_or(HeapError::ReadOutOfBounds)?
-            .read_unaligned_from_pointer(&ptr)?;
+            .read_unaligned_from_pointer(&ptr);
 
         if data.len() < 64 {
             // Not interested


### PR DESCRIPTION
## Description

This PR improves vm performance by updating `Heap` read and write related functions.

### Inspiration

We are currently iterating and applying `U256` operations with a `for` loop on some `Heap` functions, like `read`. It works, but it's not very efficient. We may replace this with functions like `U256::from_big_endian` instead.

### Changes

* `Heap::store`
* `Heap::read`
* `Heap::expanded_read`
* `Heap::read_unaligned_from_pointer`

### Results

* Up to 45% improvement on bench `heap_read_write`.
* Around 5% improvement on the other benches.
* Around 11% improvement on execution time running all but `event_spam` benches.