### PR TITLE
Move benchmark contracts to era_vm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,10 +605,9 @@ jobs:
           workspaces: |
             ${{ github.workspace }}/zksync-era/core/tests/vm-benchmark
 
-
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-flamegraph
+          tool: flamegraph
 
       - name: Check zksync-era benchmarks & era_vm build correctly
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,10 +552,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Zksync-era dependencies
+      - name: Zksync-era + perf dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: clang clang-tools build-essential librocksdb-dev
+          packages: clang clang-tools build-essential librocksdb-dev  linux-tools-common linux-tools-generic linux-perf
           version: 1.0
 
       - name: Setup nodejs + yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,9 +585,6 @@ jobs:
           chmod +x solc
           sudo cp solc /usr/bin/solc
 
-      - name: Build benchmark contracts
-        working-directory: ${{ github.workspace }}
-        run: make bench-setup
 
       - name: Fetch toolchain version from zksync-era
         run: |
@@ -599,6 +596,10 @@ jobs:
         with:
           toolchain: ${{ env.ERA_TOOLCHAIN }}
 
+      - name: Build benchmark contracts
+        working-directory: ${{ github.workspace }}
+        run: make bench-setup
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
@@ -608,6 +609,10 @@ jobs:
         run: |
           cd ${{ github.workspace }}/zksync-era
       
+      - name: Check flamegraphs target
+        working-directory: ${{ github.workspace }}
+        run: make check-flamegraph
+
       - name: Run benchmarks
         working-directory: ${{ github.workspace }}
         run: make bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,10 +614,6 @@ jobs:
         run: |
           cd ${{ github.workspace }}/zksync-era
       
-      - name: Check flamegraphs target
-        working-directory: ${{ github.workspace }}
-        run: make check-flamegraph
-
       - name: Run benchmarks
         working-directory: ${{ github.workspace }}
         run: make bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,10 +586,11 @@ jobs:
           sudo cp solc /usr/bin/solc
 
 
-      - name: Fetch toolchain version from zksync-era
+      - name: Fetch toolchain version from zksync-era + set zksync home
         run: |
           cd ${{ github.workspace }}/zksync-era
           echo "ERA_TOOLCHAIN=$(head ./rust-toolchain)" >> $GITHUB_ENV
+          echo "ZKSYNC_HOME=${{ github.workspace }}/zksync-era" >> $GITHUB_ENV
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,6 +605,11 @@ jobs:
           workspaces: |
             ${{ github.workspace }}/zksync-era/core/tests/vm-benchmark
 
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-flamegraph
+
       - name: Check zksync-era benchmarks & era_vm build correctly
         run: |
           cd ${{ github.workspace }}/zksync-era

--- a/Makefile
+++ b/Makefile
@@ -47,19 +47,19 @@ define build_zk_contracts
 	$(1)
 endef
 
-$(ZKSYNC_L1_CONTRACTS)::
+$(ZKSYNC_L1_CONTRACTS):
 	$(call build_zk_contracts, yarn l1 build)
 
-$(ZKSYNC_L2_CONTRACTS)::
+$(ZKSYNC_L2_CONTRACTS):
 	$(call build_zk_contracts, yarn l2 build)
 
-$(ZKSYNC_SYS_CONTRACTS)::
+$(ZKSYNC_SYS_CONTRACTS):
 	$(call build_zk_contracts, yarn sc build:system-contracts)
 
-$(ZKSYNC_BOOTLOADER_CONTRACT)::
+$(ZKSYNC_BOOTLOADER_CONTRACT):
 	$(call build_zk_contracts, yarn sc build:bootloader)
 
-$(ZKSYNC_BENCH_TEST_DATA)::
+$(ZKSYNC_BENCH_TEST_DATA):
 	touch $(ZKSYNC_ROOT)/etc/contracts-test-data
 	cd $(ZKSYNC_ROOT)/etc/contracts-test-data && yarn install --frozen-lockfile && yarn build
 

--- a/Makefile
+++ b/Makefile
@@ -47,19 +47,19 @@ define build_zk_contracts
 	$(1)
 endef
 
-$(ZKSYNC_L1_CONTRACTS):
+$(ZKSYNC_L1_CONTRACTS)::
 	$(call build_zk_contracts, yarn l1 build)
 
-$(ZKSYNC_L2_CONTRACTS):
+$(ZKSYNC_L2_CONTRACTS)::
 	$(call build_zk_contracts, yarn l2 build)
 
-$(ZKSYNC_SYS_CONTRACTS):
+$(ZKSYNC_SYS_CONTRACTS)::
 	$(call build_zk_contracts, yarn sc build:system-contracts)
 
-$(ZKSYNC_BOOTLOADER_CONTRACT):
+$(ZKSYNC_BOOTLOADER_CONTRACT)::
 	$(call build_zk_contracts, yarn sc build:bootloader)
 
-$(ZKSYNC_BENCH_TEST_DATA):
+$(ZKSYNC_BENCH_TEST_DATA)::
 	touch $(ZKSYNC_ROOT)/etc/contracts-test-data
 	cd $(ZKSYNC_ROOT)/etc/contracts-test-data && yarn install --frozen-lockfile && yarn build
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ bench:
 	cd $(ZKSYNC_ROOT) && cargo bench --bench criterion "$(lambda|fast_vm|legacy)/(fibonacci|send)"
 
 check-flamegraph:
-	cd $(ZKSYNC_ROOT) && CARGO_PROFILE_BENCH_DEBUG=2 cargo flamegraph --root --open --bench criterion -- --bench --profile-time 5 "$lambda/fibonacci_rec^"
+	cd $(ZKSYNC_ROOT) && CARGO_PROFILE_BENCH_DEBUG=2 cargo flamegraph --root --bench criterion -- --bench --profile-time 5 "$lambda/fibonacci_rec^"
 
 bench-base:
 	cd $(ZKSYNC_ROOT) && cargo bench --bench criterion -- --save-baseline bench_base lambda 1>bench-compare.txt

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ZKSYNC_SYS_CONTRACTS=$(ZKSYNC_ROOT)/contracts/system-contracts/artifacts-zk
 ZKSYNC_BOOTLOADER_CONTRACT=$(ZKSYNC_ROOT)/contracts/system-contracts/bootloader/build/artifacts
 ZKSYNC_BENCH_TEST_DATA=$(ZKSYNC_ROOT)/etc/contracts-test-data/artifacts-zk
 ZKSYNC_BENCH_CONTRACTS=$(ZKSYNC_ROOT)/core/tests/vm-benchmark/deployment_benchmarks
-ZKSYNC_BENCH_SOURCES=$(ZKSYNC_ROOT)/core/tests/vm-benchmark/deployment_benchmarks_sources
+BENCH_SOURCES=$(shell realpath ./deployment_benchmarks_sources)
 
 
 clean:
@@ -71,7 +71,7 @@ $(ZKSYNC_BENCH_TEST_DATA):
 #     a file insie the contract benchmarks folder.
 %.sol:
 	echo "Building benchmark contract: $@"
-	cd $(ZKSYNC_BENCH_SOURCES) && \
+	cd $(BENCH_SOURCES) && \
 	zksolc --bin $@ | grep -oE '0x[0-9a-fA-F]+' > $(ZKSYNC_BENCH_CONTRACTS)/$(basename $@)
 
 build_bench_contracts: fibonacci_rec.sol send.sol

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean lint test deps submodules bench era-test build-bench-contracts %.sol
+.PHONY: clean lint test deps submodules bench flamegraph era-test build-bench-contracts %.sol
 .SILENT: %.sol
 
 LLVM_PATH?=$(shell pwd)/era-compiler-tester/target-llvm/target-final/
@@ -83,6 +83,9 @@ bench-setup: submodules build_bench_contracts $(ZKSYNC_BENCH_TEST_DATA) $(ZKSYNC
 
 bench:
 	cd $(ZKSYNC_ROOT) && cargo bench --bench criterion "$(lambda|fast_vm|legacy)/(fibonacci|send)"
+
+flamegraph:
+	cd $(ZKSYNC_ROOT) && CARGO_PROFILE_BENCH_DEBUG=2 cargo flamegraph --root --open --bench criterion -- --bench --profile-time 5 "$lambda/fibonacci_rec^"
 
 bench-base:
 	cd $(ZKSYNC_ROOT) && cargo bench --bench criterion -- --save-baseline bench_base lambda 1>bench-compare.txt

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ bench-setup: submodules build_bench_contracts $(ZKSYNC_BENCH_TEST_DATA) $(ZKSYNC
 bench:
 	cd $(ZKSYNC_ROOT) && cargo bench --bench criterion "$(lambda|fast_vm|legacy)/(fibonacci|send)"
 
-flamegraph:
+check-flamegraph:
 	cd $(ZKSYNC_ROOT) && CARGO_PROFILE_BENCH_DEBUG=2 cargo flamegraph --root --open --bench criterion -- --bench --profile-time 5 "$lambda/fibonacci_rec^"
 
 bench-base:

--- a/bench_results.py
+++ b/bench_results.py
@@ -1,0 +1,55 @@
+import re
+import sys
+
+def convert_to_ms(value, unit):
+    if unit == 'µs':
+        return value / 1000
+    elif unit == 'ms':
+        return value
+    elif unit == 's':
+        return value * 1000
+    else:
+        raise ValueError(f"Unknown time unit: {unit}")
+
+def parse_benchmark_file(file_path):
+    machines = {}
+    pattern = r'(\w+)/\w+\s+time:\s+\[\d+(?:\.\d+)?\s(\w+)\s(\d+(?:\.\d+)?)\s(\w+)\s\d+(?:\.\d+)?\s(\w+)\]'
+
+    with open(file_path, 'r') as file:
+        content = file.read()
+        # Clean the file content
+        cleaned_content = re.sub(r'\n(\s+)time:', ' time:', content)
+        for line in cleaned_content.split('\n'):
+            match = re.match(pattern, line)
+            if match:
+                machine, lower_unit, mid_time, mid_unit, upper_unit = match.groups()
+                # Convert mid_time to milliseconds
+                mid_time_ms = convert_to_ms(float(mid_time), mid_unit)
+                machines[machine] = machines.get(machine, 0) + mid_time_ms
+
+    return machines
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: results.py <path-to-file>")
+        return
+    file_path = sys.argv[1]
+    results = parse_benchmark_file(file_path)
+
+    for machine, total_time in results.items():
+        print(f"Total {machine} time: {total_time:.3f} ms")
+
+    if not "lambda" in results:
+        return
+
+    print("")
+
+    if "legacy" in results:
+        lambda_vs_legacy = round(results["lambda"] / results["legacy"], 1)
+        print(f"lambda_vm took x{lambda_vs_legacy} more than legacy_vm")
+    if "fast" in results:
+        lambda_vs_fast = round(results["lambda"] / results["fast"], 1)
+        print(f"lambda_vm took x{lambda_vs_fast} more than fast_vm")
+
+if __name__ == "__main__":
+    main()

--- a/deployment_benchmarks_sources/factorial_it.sol
+++ b/deployment_benchmarks_sources/factorial_it.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.8.0;
+
+contract benchmark {
+    uint256 value;
+    constructor() {
+      value = fac(57);
+    }
+
+    function get_calculation() public view returns (uint256) {
+        return value;
+    }
+
+    function fac(uint n) internal pure returns(uint256) { 
+        uint256 r = 1;
+        for (uint256 k = 2; k <= n; k++) {
+            r = k * r;
+        }
+
+        return r;
+    }
+}
+

--- a/deployment_benchmarks_sources/factorial_rec.sol
+++ b/deployment_benchmarks_sources/factorial_rec.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.8.0;
+
+contract benchmark {
+    uint256 value;
+    constructor() {
+      value = fac(57);
+    }
+
+    function get_calculation() public view returns (uint256) {
+        return value;
+    }
+
+    function fac(uint256 n) internal returns (uint256) {
+        if (n <= 1) {
+            return 1;
+        }
+        return n * fac(n - 1);
+    }
+}
+

--- a/deployment_benchmarks_sources/fibonacci_it.sol
+++ b/deployment_benchmarks_sources/fibonacci_it.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.8.0;
+
+contract benchmark {
+    uint256 value;
+    constructor() {
+      value = fib(370);
+    }
+
+    function get_calculation() public view returns (uint256) {
+        return value;
+    }
+
+    function fib(uint n) internal pure returns(uint b) { 
+        if (n == 0) {
+            return 0;   
+        }
+        uint a = 1;
+        b = 1;
+        for (uint i = 2; i < n; i++) {
+            uint c = a + b;
+            a = b;
+            b = c;
+        }
+        return b;
+    }
+}

--- a/deployment_benchmarks_sources/fibonacci_rec.sol
+++ b/deployment_benchmarks_sources/fibonacci_rec.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.8.0;
+
+contract benchmark {
+    uint256 value;
+    constructor() {
+      value = fib(25);
+    }
+
+    function get_calculation() public view returns (uint256) {
+        return value;
+    }
+
+    function fib(uint256 n) internal returns (uint256) {
+        if (n <= 1) {
+            return n;
+        }
+        return fib(n - 1) + fib(n - 2);
+    }
+}

--- a/deployment_benchmarks_sources/heap_read_write.sol
+++ b/deployment_benchmarks_sources/heap_read_write.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.8.0;
+
+contract HeapBenchmark {
+    constructor() {
+        uint256 v1 = 0;
+        uint256 v2 = 0;
+        uint256 n = 16000;
+        uint256[] memory array = new uint256[](1);
+
+        assembly {
+            mstore(add(array, sub(n, 1)), 4242)
+
+            let j := 0
+            for {} lt(j, n) {} {
+                v1 := mload(add(array, mod(mul(j, j), n)))
+                v2 := mload(add(array, j))
+                mstore(add(array, j), add(add(v1, v2), 42))
+                j := add(j, 1) 
+                if gt(j, sub(n, 1)) {
+                    j := 0
+                }
+            }
+        }
+    }
+}

--- a/deployment_benchmarks_sources/send.sol
+++ b/deployment_benchmarks_sources/send.sol
@@ -1,0 +1,8 @@
+pragma solidity >=0.8.20;
+
+contract Send {
+    constructor() {
+        address payable self = payable(msg.sender);
+        self.call{value: 100};
+    }
+}


### PR DESCRIPTION
This PR moves custom made benchmark contracts sources from zksync-era to era_vm, so its easier to modify them.
It also adds a new benchmark result processing script made in python, which allows us to easily aggregate all benchmark execution times.