### PR TITLE
makefile: do not use grep to fetch bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ program_artifacts
 .test_db*
 **/.DS_Store
 era-compiler-tester
+./fibonacci
+./send
+**/*.zbin

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.PHONY: clean lint test deps submodules bench flamegraph era-test build-bench-contracts %.sol
+.PHONY: clean lint test deps submodules bench flamegraph era-test build_bench_contracts send.sol fibonacci_rec.sol
 .SILENT: %.sol
 
 LLVM_PATH?=$(shell pwd)/era-compiler-tester/target-llvm/target-final/
-ZKSYNC_ROOT=$(shell realpath ./zksync-era)
+ZKSYNC_ROOT=$(shell realpath /Users/franciscokrausearnim/Programming/zksync/zksync-era)
 ZKSYNC_L1_CONTRACTS=$(ZKSYNC_ROOT)/contracts/l1-contracts/artifacts
 ZKSYNC_L2_CONTRACTS=$(ZKSYNC_ROOT)/contracts/l2-contracts/artifacts-zk
 ZKSYNC_SYS_CONTRACTS=$(ZKSYNC_ROOT)/contracts/system-contracts/artifacts-zk
@@ -63,16 +63,12 @@ $(ZKSYNC_BENCH_TEST_DATA):
 	touch $(ZKSYNC_ROOT)/etc/contracts-test-data
 	cd $(ZKSYNC_ROOT)/etc/contracts-test-data && yarn install --frozen-lockfile && yarn build
 
-# Steps:
-# 1 - cd
-# 2 - Take the given CONTRACT.sol and get its byte code
-# 3 - Parse the output
-# 4 - Redirect the hexstring to a CONTRACT (mind the extension-less name) to
-#     a file insie the contract benchmarks folder.
-%.sol:
-	echo "Building benchmark contract: $@"
-	cd $(BENCH_SOURCES) && \
-	zksolc --bin $@ | grep -oE '0x[0-9a-fA-F]+' > $(ZKSYNC_BENCH_CONTRACTS)/$(basename $@)
+
+send.sol:
+	zksolc deployment_benchmarks_sources/send.sol --bin --overwrite -o  ./send && cp ./send/send.sol/Send.zbin $(ZKSYNC_BENCH_CONTRACTS)/send
+
+fibonacci_rec.sol:
+	 zksolc deployment_benchmarks_sources/fibonacci_rec.sol --bin --overwrite -o ./fibonacci && cp ./fibonacci/fibonacci_rec.sol/Fibonacci.zbin $(ZKSYNC_BENCH_CONTRACTS)/fibonacci
 
 build_bench_contracts: fibonacci_rec.sol send.sol
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .SILENT: %.sol
 
 LLVM_PATH?=$(shell pwd)/era-compiler-tester/target-llvm/target-final/
-ZKSYNC_ROOT=$(shell realpath /Users/franciscokrausearnim/Programming/zksync/zksync-era)
+ZKSYNC_ROOT=$(shell realpath ./zksync-era)
 ZKSYNC_L1_CONTRACTS=$(ZKSYNC_ROOT)/contracts/l1-contracts/artifacts
 ZKSYNC_L2_CONTRACTS=$(ZKSYNC_ROOT)/contracts/l2-contracts/artifacts-zk
 ZKSYNC_SYS_CONTRACTS=$(ZKSYNC_ROOT)/contracts/system-contracts/artifacts-zk

--- a/deployment_benchmarks_sources/fibonacci_rec.sol
+++ b/deployment_benchmarks_sources/fibonacci_rec.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.0;
 
-contract benchmark {
+contract Fibonacci {
     uint256 value;
     constructor() {
       value = fib(25);


### PR DESCRIPTION
## Changes:
- To avoid potential issues with byte code parsing, I'm hardcoding the current benchmarking contracts, if 
  we ever have a bunch more, we can always create a generic make target, but for now I think this works.